### PR TITLE
fix: ドキュメント内のリンク切れを修正

### DIFF
--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -80,5 +80,5 @@ IconProgress {
 
 - [アーキテクチャ概要](overview.md) - システム全体の構造
 - [IPCチャンネル詳細](ipc-channels.md) - 各IPCチャンネルの仕様
-- [編集モード](../features/edit-mode.md) - 編集モードの詳細仕様
+- [アイテム管理](../features/item-management.md) - 編集モードの詳細仕様
 - [アイコンシステム](../features/icon-system.md) - アイコン取得・管理システム

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -200,7 +200,7 @@ QuickDashLauncherではCSS変数ベースの統一されたデザインシステ
 
 ## 関連ドキュメント
 
-- [編集モード詳細ガイド](../features/edit-mode.md) - 編集モードの操作方法と技術実装
+- [アイテム管理詳細ガイド](../features/item-management.md) - 編集モードの操作方法と技術実装
 - [CSSデザインシステム](../features/css-design-system.md) - 統一されたスタイル管理システム
 - [ビルドとデプロイ](build-and-deploy.md) - ビルドシステムと配布方法
 - [テストチェックリスト](testing.md) - 手動テストの手順

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -106,6 +106,6 @@ dir,C:\Scripts,filter=*.ps1,prefix=Script
 
 - [開発ガイド](development.md) - 詳細な開発情報
 - [ビルドとデプロイ](build-and-deploy.md) - ビルドシステムとデプロイ方法
-- [編集モード](../features/edit-mode.md) - 編集モードの使い方
+- [アイテム管理](../features/item-management.md) - 編集モードの使い方
 - [アイコンシステム](../features/icon-system.md) - アイコン機能の詳細
 - [アプリケーション設定](../features/app-settings.md) - ホットキーや表示設定のカスタマイズ

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -80,5 +80,5 @@
 ## 関連ドキュメント
 
 - [開発ガイド](development.md) - 基本的な開発情報
-- [編集モード](../features/edit-mode.md) - 編集モードのテスト項目
+- [アイテム管理](../features/item-management.md) - 編集モードのテスト項目
 - [ビルドとデプロイ](build-and-deploy.md) - ビルド後のテスト手順

--- a/docs/reference/bookmark-import-modal.md
+++ b/docs/reference/bookmark-import-modal.md
@@ -4,7 +4,7 @@
 
 - [画面一覧](screen-list.md) - 全画面構成の概要
 - [メインウィンドウ](main-window.md) - メイン画面の詳細仕様
-- [編集モード](../features/edit-mode.md) - 編集機能の詳細
+- [アイテム管理](../features/item-management.md) - 編集機能の詳細
 
 ## 1. 概要
 

--- a/docs/reference/main-window.md
+++ b/docs/reference/main-window.md
@@ -4,7 +4,7 @@
 
 - [画面一覧](screen-list.md) - 全画面構成の概要
 - [ブックマークインポートモーダル](bookmark-import-modal.md) - インポート機能詳細
-- [編集モード](../features/edit-mode.md) - 編集機能の詳細
+- [アイテム管理](../features/item-management.md) - 編集機能の詳細
 
 ## 1. 概要
 

--- a/docs/reference/screen-list.md
+++ b/docs/reference/screen-list.md
@@ -50,10 +50,10 @@ QuickDashLauncher
 
 | 画面名 | ファイル | 種類 | 表示条件 | 主要機能 |
 |--------|----------|------|----------|----------|
-| **メインウィンドウ** | `src/renderer/App.tsx` | ウィンドウ | 起動時のデフォルト状態 | 検索ボックス、アイテム一覧、アクションボタン、タブ切り替え<br>📋 [詳細仕様書](../screens/main-window.md) |
+| **メインウィンドウ** | `src/renderer/App.tsx` | ウィンドウ | 起動時のデフォルト状態 | 検索ボックス、アイテム一覧、アクションボタン、タブ切り替え<br>📋 [詳細仕様書](main-window.md) |
 | **管理ウィンドウ** | `src/renderer/AdminApp.tsx` | ウィンドウ | Ctrl+E または設定メニューから | 生データ編集、アプリケーション設定、サイズ1000x700px、独立ウィンドウ |
 | **アイテム登録・編集モーダル** | `src/renderer/components/RegisterModal.tsx` | モーダル | ファイルドラッグ&ドロップ時<br>アイテム管理で詳細編集時 | アイテム登録・編集、フォルダ取込オプション設定、保存先選択 |
-| **ブックマークインポートモーダル** | `src/renderer/components/BookmarkImportModal.tsx` | モーダル | 管理ウィンドウでインポートボタンクリック時 | ブックマークHTMLファイルのインポート、検索・選択<br>📋 [詳細仕様書](../screens/bookmark-import-modal.md) |
+| **ブックマークインポートモーダル** | `src/renderer/components/BookmarkImportModal.tsx` | モーダル | 管理ウィンドウでインポートボタンクリック時 | ブックマークHTMLファイルのインポート、検索・選択<br>📋 [詳細仕様書](bookmark-import-modal.md) |
 
 ## コンポーネント一覧
 


### PR DESCRIPTION
## Summary
ドキュメント内のリンク切れ問題を修正しました。

- docs/reference/screen-list.mdの不正なパス参照を修正
- 存在しないedit-mode.mdへのリンクをitem-management.mdに統一

## Test plan
- [ ] すべてのドキュメントリンクが正しく機能することを確認
- [ ] CLAUDE.mdから参照されるすべてのファイルが存在することを確認
- [ ] docs/reference/内のファイル間リンクが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)