### PR TITLE
feat: implement 3-stage window pinning mode

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -120,3 +120,12 @@ export interface IconProgressState {
   /** 現在の進捗情報 */
   progress: IconProgress | null;
 }
+
+/**
+ * ウィンドウの固定モードを表す列挙型
+ * 3段階のモードを循環的に切り替え可能
+ */
+export type WindowPinMode = 
+  | 'normal'        // 通常モード: フォーカスが外れたら非表示、最上面ではない
+  | 'alwaysOnTop'   // 常に最上面モード: 常に最上面に表示、フォーカスが外れても非表示にならない
+  | 'stayVisible';  // 表示固定モード: 最上面ではないが、フォーカスが外れても非表示にならない

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow } from 'electron';
+import type { WindowPinMode } from '@common/types';
 
 import { setupDataHandlers } from './dataHandlers';
 import { setupItemHandlers } from './itemHandlers';
@@ -17,13 +18,15 @@ export function setupIPCHandlers(
   getWindowPinState: () => boolean,
   setWindowPinState: (pinState: boolean) => void,
   setEditMode: (editMode: boolean) => Promise<void>,
-  getEditMode: () => boolean
+  getEditMode: () => boolean,
+  getWindowPinMode: () => WindowPinMode,
+  cycleWindowPinMode: () => WindowPinMode
 ) {
   setupDataHandlers(configFolder);
   setupItemHandlers(getMainWindow);
   setupConfigHandlers(configFolder);
   setupIconHandlers(faviconsFolder, iconsFolder, extensionsFolder, getMainWindow);
-  setupWindowHandlers(getWindowPinState, setWindowPinState, setEditMode, getEditMode);
+  setupWindowHandlers(getWindowPinState, setWindowPinState, setEditMode, getEditMode, getWindowPinMode, cycleWindowPinMode);
   registerEditHandlers(configFolder);
   setupSettingsHandlers();
 }

--- a/src/main/ipc/windowHandlers.ts
+++ b/src/main/ipc/windowHandlers.ts
@@ -1,4 +1,5 @@
 import { ipcMain, app, clipboard } from 'electron';
+import type { WindowPinMode } from '@common/types';
 
 import {
   showAdminWindow,
@@ -13,8 +14,20 @@ export function setupWindowHandlers(
   getWindowPinState: () => boolean,
   setWindowPinState: (pinState: boolean) => void,
   setEditMode: (editMode: boolean) => Promise<void>,
-  getEditMode: () => boolean
+  getEditMode: () => boolean,
+  getWindowPinMode: () => WindowPinMode,
+  cycleWindowPinMode: () => WindowPinMode
 ) {
+  // 新しい3段階モード用のIPCハンドラー
+  ipcMain.handle('get-window-pin-mode', () => {
+    return getWindowPinMode();
+  });
+
+  ipcMain.handle('cycle-window-pin-mode', () => {
+    return cycleWindowPinMode();
+  });
+
+  // 旧APIとの互換性のためのIPCハンドラー（非推奨）
   ipcMain.handle('get-window-pin-state', () => {
     return getWindowPinState();
   });

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -20,6 +20,8 @@ import {
   setWindowPinState,
   setEditMode,
   getEditMode,
+  getWindowPinMode,
+  cycleWindowPinMode,
 } from './windowManager';
 import { closeAdminWindow } from './adminWindowManager';
 
@@ -66,7 +68,9 @@ app.whenReady().then(async () => {
     getWindowPinState,
     setWindowPinState,
     setEditMode,
-    getEditMode
+    getEditMode,
+    getWindowPinMode,
+    cycleWindowPinMode
   );
 });
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
 
-import { LauncherItem, RawDataLine, AppSettings, IconProgress } from '../common/types';
+import { LauncherItem, RawDataLine, AppSettings, IconProgress, WindowPinMode } from '../common/types';
 
 interface RegisterItem {
   filePath: string;
@@ -51,6 +51,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onSetActiveTab: (callback: (tab: 'settings' | 'edit' | 'other') => void) => {
     ipcRenderer.on('set-active-tab', (_event, tab) => callback(tab));
   },
+  // 新しい3段階ピンモードAPI
+  getWindowPinMode: () => ipcRenderer.invoke('get-window-pin-mode'),
+  cycleWindowPinMode: () => ipcRenderer.invoke('cycle-window-pin-mode'),
+  // 旧APIとの互換性（非推奨）
   getWindowPinState: () => ipcRenderer.invoke('get-window-pin-state'),
   setWindowPinState: (isPinned: boolean) => ipcRenderer.invoke('set-window-pin-state', isPinned),
   registerItems: (items: RegisterItem[]) => ipcRenderer.invoke('register-items', items),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 
-import { LauncherItem } from '../common/types';
+import { LauncherItem, WindowPinMode } from '../common/types';
 
 import SearchBox from './components/SearchBox';
 import ItemList from './components/ItemList';
@@ -14,7 +14,7 @@ const App: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [mainItems, setMainItems] = useState<LauncherItem[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [isPinned, setIsPinned] = useState(false);
+  const [windowPinMode, setWindowPinMode] = useState<WindowPinMode>('normal');
   const [isRegisterModalOpen, setIsRegisterModalOpen] = useState(false);
   const [droppedPaths, setDroppedPaths] = useState<string[]>([]);
   const [isDraggingOver, setIsDraggingOver] = useState(false);
@@ -31,10 +31,10 @@ const App: React.FC = () => {
       searchInputRef.current?.focus();
     });
 
-    // Load initial pin state
+    // Load initial pin mode
     const loadPinState = async () => {
-      const pinState = await window.electronAPI.getWindowPinState();
-      setIsPinned(pinState);
+      const pinMode = await window.electronAPI.getWindowPinMode();
+      setWindowPinMode(pinMode);
     };
     loadPinState();
 
@@ -253,9 +253,8 @@ const App: React.FC = () => {
   };
 
   const handleTogglePin = async () => {
-    const newPinState = !isPinned;
-    await window.electronAPI.setWindowPinState(newPinState);
-    setIsPinned(newPinState);
+    const newPinMode = await window.electronAPI.cycleWindowPinMode();
+    setWindowPinMode(newPinMode);
   };
 
   const handleExportJson = async () => {
@@ -318,7 +317,7 @@ const App: React.FC = () => {
             onExportJson={handleExportJson}
             onOpenBasicSettings={handleOpenBasicSettings}
             onOpenItemManagement={handleOpenItemManagement}
-            isPinned={isPinned}
+            windowPinMode={windowPinMode}
             isEditMode={false}
           />
         </div>

--- a/src/renderer/components/ActionButtons.tsx
+++ b/src/renderer/components/ActionButtons.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import type { WindowPinMode } from '../../common/types';
 import SettingsDropdown from './SettingsDropdown';
 import RefreshActionsDropdown from './RefreshActionsDropdown';
 
@@ -11,7 +12,7 @@ interface ActionButtonsProps {
   onExportJson: () => void;
   onOpenBasicSettings: () => void;
   onOpenItemManagement: () => void;
-  isPinned: boolean;
+  windowPinMode: WindowPinMode;
   isEditMode: boolean;
 }
 
@@ -23,9 +24,34 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
   onExportJson,
   onOpenBasicSettings,
   onOpenItemManagement,
-  isPinned,
+  windowPinMode,
   isEditMode,
 }) => {
+  // 各モードの表示設定
+  const getPinButtonConfig = (mode: WindowPinMode) => {
+    switch (mode) {
+      case 'normal':
+        return {
+          className: 'action-button pin-normal',
+          title: '通常モード → 常に最上面モード',
+          emoji: '📌',
+        };
+      case 'alwaysOnTop':
+        return {
+          className: 'action-button pin-always-on-top',
+          title: '常に最上面モード → 表示固定モード',
+          emoji: '📌',
+        };
+      case 'stayVisible':
+        return {
+          className: 'action-button pin-stay-visible',
+          title: '表示固定モード → 通常モード',
+          emoji: '📌',
+        };
+    }
+  };
+
+  const pinConfig = getPinButtonConfig(windowPinMode);
   return (
     <div className="action-buttons">
       <RefreshActionsDropdown
@@ -34,11 +60,11 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
         onRefreshAll={onRefreshAll}
       />
       <button
-        className={`action-button ${isPinned ? 'pinned' : ''}`}
+        className={pinConfig.className}
         onClick={onTogglePin}
-        title={isPinned ? '固定解除' : 'ウィンドウを固定'}
+        title={pinConfig.title}
       >
-        📌
+        {pinConfig.emoji}
       </button>
       <SettingsDropdown
         onOpenBasicSettings={onOpenBasicSettings}

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -5,6 +5,7 @@ import {
   SimpleBookmarkItem,
   AppSettings,
   IconProgress,
+  WindowPinMode,
 } from '../common/types';
 
 import { RegisterItem } from './components/RegisterModal';
@@ -31,6 +32,10 @@ export interface ElectronAPI {
   ) => void;
   onWindowShown: (callback: () => void) => void;
   onSetActiveTab: (callback: (tab: 'settings' | 'edit' | 'other') => void) => void;
+  // 新しい3段階ピンモードAPI
+  getWindowPinMode: () => Promise<WindowPinMode>;
+  cycleWindowPinMode: () => Promise<WindowPinMode>;
+  // 旧APIとの互換性（非推奨）
   getWindowPinState: () => Promise<boolean>;
   setWindowPinState: (isPinned: boolean) => Promise<void>;
   registerItems: (items: RegisterItem[]) => Promise<void>;

--- a/src/renderer/styles/components/Header.css
+++ b/src/renderer/styles/components/Header.css
@@ -54,6 +54,41 @@
   background-color: var(--color-gray-400);
 }
 
+/* 3段階ピンモードのスタイル */
+.action-button.pin-normal {
+  background-color: var(--color-white);
+  color: var(--text-primary);
+  border-color: var(--color-gray-400);
+}
+
+.action-button.pin-normal:hover {
+  background-color: var(--bg-hover);
+  border-color: var(--color-gray-600);
+}
+
+.action-button.pin-always-on-top {
+  background-color: #dc3545; /* 赤色 */
+  color: var(--color-white);
+  border-color: #dc3545;
+}
+
+.action-button.pin-always-on-top:hover {
+  background-color: #c82333;
+  border-color: #c82333;
+}
+
+.action-button.pin-stay-visible {
+  background-color: var(--color-primary); /* 青色 */
+  color: var(--color-white);
+  border-color: var(--color-primary);
+}
+
+.action-button.pin-stay-visible:hover {
+  background-color: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
+}
+
+/* 旧スタイルとの互換性（非推奨） */
 .action-button.pinned {
   background-color: var(--color-primary);
   color: var(--color-white);


### PR DESCRIPTION
## Summary

3段階のウィンドウ固定モードを実装しました。

**主要変更点**:
- 📌ボタンクリックで循環式に3モード切り替え
- 各モードの視覚的フィードバック（グレー/赤/青）
- 既存のバグ修正：ピン状態が実際のウィンドウ動作に反映

**3つのモード**:
1. **通常モード** - フォーカスが外れたら非表示
2. **常に最上面モード** - 常に最上面に表示
3. **表示固定モード** - 最上面ではないが表示は維持

Closes #4

Generated with [Claude Code](https://claude.ai/code)