### PR TITLE
fix: 「アプリを終了」ボタンでプロセスが完全に終了しない問題を修正

### DIFF
--- a/src/main/ipc/windowHandlers.ts
+++ b/src/main/ipc/windowHandlers.ts
@@ -9,6 +9,7 @@ import {
   showAdminWindowWithTab,
   getInitialTab,
 } from '../adminWindowManager.js';
+import { getTray } from '../windowManager.js';
 
 export function setupWindowHandlers(
   getWindowPinState: () => boolean,
@@ -37,7 +38,11 @@ export function setupWindowHandlers(
   });
 
   ipcMain.handle('quit-app', () => {
-    app.quit();
+    const tray = getTray();
+    if (tray) {
+      tray.destroy();
+    }
+    app.exit(0);
   });
 
   ipcMain.handle('set-edit-mode', async (_event, editMode: boolean) => {

--- a/src/main/windowManager.ts
+++ b/src/main/windowManager.ts
@@ -256,3 +256,7 @@ export async function setEditMode(editMode: boolean): Promise<void> {
 export function getEditMode(): boolean {
   return isEditMode;
 }
+
+export function getTray(): Tray | null {
+  return tray;
+}


### PR DESCRIPTION
## Summary
- 「アプリを終了」ボタンを押してもElectronプロセスが完全に終了しない問題を修正
- quit-appハンドラーでシステムトレイを破棄してから強制終了するように変更

## 修正内容
- `windowManager.ts`: トレイインスタンスを取得する`getTray()`関数を追加
- `windowHandlers.ts`: `quit-app`ハンドラーを修正
  - トレイが存在する場合は`tray.destroy()`で破棄
  - `app.quit()`の代わりに`app.exit(0)`で強制終了

## Test plan
- [x] ビルドが正常に完了することを確認
- [ ] アプリケーションを起動
- [ ] 「アプリを終了」ボタンをクリック
- [ ] タスクマネージャーでElectronプロセスが完全に終了することを確認

Fixes #30

🤖 Generated with [Claude Code](https://claude.ai/code)