### PR TITLE
feat: ドラッグ&ドロップ時の動的ウィンドウリサイズ機能を実装 (Issue #33)

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -20,7 +20,11 @@ export function setupIPCHandlers(
   setEditMode: (editMode: boolean) => Promise<void>,
   getEditMode: () => boolean,
   getWindowPinMode: () => WindowPinMode,
-  cycleWindowPinMode: () => WindowPinMode
+  cycleWindowPinMode: () => WindowPinMode,
+  setModalMode: (
+    isModal: boolean,
+    requiredSize?: { width: number; height: number }
+  ) => Promise<void>
 ) {
   setupDataHandlers(configFolder);
   setupItemHandlers(getMainWindow);
@@ -32,7 +36,8 @@ export function setupIPCHandlers(
     setEditMode,
     getEditMode,
     getWindowPinMode,
-    cycleWindowPinMode
+    cycleWindowPinMode,
+    setModalMode
   );
   registerEditHandlers(configFolder);
   setupSettingsHandlers();

--- a/src/main/ipc/windowHandlers.ts
+++ b/src/main/ipc/windowHandlers.ts
@@ -16,7 +16,11 @@ export function setupWindowHandlers(
   setEditMode: (editMode: boolean) => Promise<void>,
   getEditMode: () => boolean,
   getWindowPinMode: () => WindowPinMode,
-  cycleWindowPinMode: () => WindowPinMode
+  cycleWindowPinMode: () => WindowPinMode,
+  setModalMode: (
+    isModal: boolean,
+    requiredSize?: { width: number; height: number }
+  ) => Promise<void>
 ) {
   // 新しい3段階モード用のIPCハンドラー
   ipcMain.handle('get-window-pin-mode', () => {
@@ -84,4 +88,11 @@ export function setupWindowHandlers(
       return false;
     }
   });
+
+  ipcMain.handle(
+    'set-modal-mode',
+    async (_event, isModal: boolean, requiredSize?: { width: number; height: number }) => {
+      await setModalMode(isModal, requiredSize);
+    }
+  );
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -22,6 +22,7 @@ import {
   getEditMode,
   getWindowPinMode,
   cycleWindowPinMode,
+  setModalMode,
 } from './windowManager';
 import { closeAdminWindow } from './adminWindowManager';
 
@@ -70,7 +71,8 @@ app.whenReady().then(async () => {
     setEditMode,
     getEditMode,
     getWindowPinMode,
-    cycleWindowPinMode
+    cycleWindowPinMode,
+    setModalMode
   );
 });
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -99,4 +99,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('open-edit-window-with-tab', tab),
   getInitialTab: () => ipcRenderer.invoke('get-initial-tab'),
   copyToClipboard: (text: string) => ipcRenderer.invoke('copy-to-clipboard', text),
+  setModalMode: (isModal: boolean, requiredSize?: { width: number; height: number }) =>
+    ipcRenderer.invoke('set-modal-mode', isModal, requiredSize),
 });

--- a/src/main/windowManager.ts
+++ b/src/main/windowManager.ts
@@ -256,3 +256,35 @@ export async function setEditMode(editMode: boolean): Promise<void> {
 export function getEditMode(): boolean {
   return isEditMode;
 }
+
+/**
+ * モーダルモードの切り替え
+ * モーダル表示時は必要に応じてウィンドウサイズを拡大し、閉じる時は元のサイズに戻す
+ */
+export async function setModalMode(
+  isModal: boolean,
+  requiredSize?: { width: number; height: number }
+): Promise<void> {
+  if (mainWindow) {
+    if (isModal && requiredSize) {
+      // モーダル表示時：現在のサイズを保存し、必要な場合のみ拡大
+      const currentBounds = mainWindow.getBounds();
+      normalWindowBounds = { width: currentBounds.width, height: currentBounds.height };
+
+      // 必要サイズと現在サイズを比較し、必要な場合のみ拡大
+      if (currentBounds.width < requiredSize.width || currentBounds.height < requiredSize.height) {
+        mainWindow.setSize(
+          Math.max(currentBounds.width, requiredSize.width),
+          Math.max(currentBounds.height, requiredSize.height)
+        );
+        mainWindow.center();
+      }
+    } else {
+      // モーダルを閉じる時：元のサイズに復元
+      if (normalWindowBounds) {
+        mainWindow.setSize(normalWindowBounds.width, normalWindowBounds.height);
+        mainWindow.center();
+      }
+    }
+  }
+}

--- a/src/renderer/components/RegisterModal.tsx
+++ b/src/renderer/components/RegisterModal.tsx
@@ -46,6 +46,7 @@ const RegisterModal: React.FC<RegisterModalProps> = ({
     if (!isOpen) {
       // モーダルが閉じられたときの処理
       document.body.style.overflow = 'auto';
+      window.electronAPI.setModalMode(false);
       return;
     }
 
@@ -154,6 +155,19 @@ const RegisterModal: React.FC<RegisterModalProps> = ({
       document.body.style.overflow = 'auto';
     };
   }, [isOpen, droppedPaths, editingItem]);
+
+  // アイテムの内容が変更されたときにモーダルサイズを調整
+  useEffect(() => {
+    if (!isOpen || items.length === 0) return;
+
+    // 必要サイズを計算
+    const hasFolderItem = items.some((item) => item.itemCategory === 'dir');
+    const requiredWidth = hasFolderItem ? 900 : 800;
+    const requiredHeight = hasFolderItem ? 700 : 600;
+
+    // モーダルモードを有効化し、必要サイズを設定
+    window.electronAPI.setModalMode(true, { width: requiredWidth, height: requiredHeight });
+  }, [isOpen, items]);
 
   const initializeFromEditingItem = async () => {
     setLoading(true);

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -77,6 +77,10 @@ export interface ElectronAPI {
   openEditWindowWithTab: (tab: 'settings' | 'edit' | 'other') => Promise<void>;
   getInitialTab: () => Promise<'settings' | 'edit' | 'other'>;
   copyToClipboard: (text: string) => Promise<boolean>;
+  setModalMode: (
+    isModal: boolean,
+    requiredSize?: { width: number; height: number }
+  ) => Promise<void>;
 }
 
 declare global {


### PR DESCRIPTION
## Summary
- Issue #33の要件に対応し、RegisterModal表示時の動的ウィンドウリサイズ機能を実装
- 通常アイテム（800x600px）とフォルダ取込アイテム（900x700px）で適切なサイズを自動調整
- モーダル閉じる時に元のウィンドウサイズに完全復元

## 実装内容
- `setModalMode`関数を新規追加（既存の`setEditMode`パターンを参考）
- IPCハンドラー`set-modal-mode`を追加
- RegisterModalでアイテム種別に応じた動的サイズ計算を実装

## Test plan
- [x] 通常アイテムのドラッグ&ドロップでウィンドウサイズが適切に調整される
- [x] フォルダ取込アイテムでより大きなサイズに調整される  
- [x] モーダル閉じる時に元のサイズに正しく復元される
- [x] TypeScript型チェック通過
- [x] ESLint品質チェック通過
- [x] ビルドテスト成功

🤖 Generated with [Claude Code](https://claude.ai/code)