### PR TITLE
fix: アイテム管理画面のCtrl+A全選択機能を廃止

### DIFF
--- a/src/renderer/components/EditModeView.tsx
+++ b/src/renderer/components/EditModeView.tsx
@@ -254,17 +254,6 @@ const EditModeView: React.FC<EditModeViewProps> = ({
     return keywords.every((keyword) => lineText.includes(keyword));
   });
 
-  useEffect(() => {
-    const handleGlobalKeyDown = (e: KeyboardEvent) => {
-      if (e.ctrlKey && e.key === 'a') {
-        e.preventDefault();
-        handleSelectAll(true);
-      }
-    };
-
-    window.addEventListener('keydown', handleGlobalKeyDown);
-    return () => window.removeEventListener('keydown', handleGlobalKeyDown);
-  }, []);
 
   // rawLinesが変更されたらworkingLinesも更新
   useEffect(() => {


### PR DESCRIPTION
## 概要
アイテム管理画面でCtrl+Aを押した際の自動全選択機能を廃止しました。

## 変更内容
- EditModeView.tsxのuseEffect hook（257-267行）を削除
- ブラウザ標準のCtrl+A動作（テキスト選択）を復元
- 誤操作による大量アイテム削除のリスクを軽減

Closes #45

Generated with [Claude Code](https://claude.ai/code)