### PR TITLE
feat: コマンドヒストリー機能の実装

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -139,3 +139,25 @@ export type WindowPinMode =
   | 'normal' // 通常モード: フォーカスが外れたら非表示、最上面ではない
   | 'alwaysOnTop' // 常に最上面モード: 常に最上面に表示、フォーカスが外れても非表示にならない
   | 'stayVisible'; // 表示固定モード: 最上面ではないが、フォーカスが外れても非表示にならない
+
+/**
+ * 検索履歴のエントリーを表すインターフェース
+ * ユーザーが実行時に入力した検索クエリと実行日時を保持する
+ */
+export interface SearchHistoryEntry {
+  /** 検索クエリ文字列 */
+  query: string;
+  /** 実行日時（ISO文字列形式） */
+  timestamp: string;
+}
+
+/**
+ * 検索履歴の状態管理用インターフェース
+ * キーボードナビゲーションでの履歴巡回に使用される
+ */
+export interface SearchHistoryState {
+  /** 履歴エントリーのリスト（最新が先頭） */
+  entries: SearchHistoryEntry[];
+  /** 現在選択中の履歴インデックス（-1は履歴を使用していない状態） */
+  currentIndex: number;
+}

--- a/src/main/ipc/historyHandlers.ts
+++ b/src/main/ipc/historyHandlers.ts
@@ -1,0 +1,43 @@
+import { ipcMain } from 'electron';
+import { SearchHistoryService } from '../services/searchHistoryService';
+import { SearchHistoryEntry } from '@common/types';
+
+let searchHistoryService: SearchHistoryService | null = null;
+
+/**
+ * 検索履歴関連のIPCハンドラーを設定する
+ * @param configFolder 設定ファイルフォルダのパス
+ */
+export function setupHistoryHandlers(configFolder: string) {
+  searchHistoryService = new SearchHistoryService(configFolder);
+
+  // 検索履歴の読み込み
+  ipcMain.handle('load-search-history', async (): Promise<SearchHistoryEntry[]> => {
+    if (!searchHistoryService) return [];
+    return searchHistoryService.loadHistory();
+  });
+
+  // 検索履歴の保存
+  ipcMain.handle('save-search-history', async (_event, entries: SearchHistoryEntry[]): Promise<void> => {
+    if (!searchHistoryService) return;
+    searchHistoryService.saveHistory(entries);
+  });
+
+  // 検索履歴エントリーの追加
+  ipcMain.handle('add-search-history-entry', async (_event, query: string): Promise<void> => {
+    if (!searchHistoryService) return;
+    searchHistoryService.addHistoryEntry(query);
+  });
+
+  // 検索履歴のクリア
+  ipcMain.handle('clear-search-history', async (): Promise<void> => {
+    if (!searchHistoryService) return;
+    searchHistoryService.clearHistory();
+  });
+
+  // 内部的な履歴追加イベント（itemHandlersから呼ばれる）
+  ipcMain.on('add-search-history-entry-internal', async (query: string) => {
+    if (!searchHistoryService) return;
+    searchHistoryService.addHistoryEntry(query);
+  });
+}

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -9,6 +9,7 @@ import { setupWindowHandlers } from './windowHandlers';
 import { registerEditHandlers } from './editHandlers';
 import { setupSettingsHandlers } from './settingsHandlers';
 import { setupSplashHandlers } from './splashHandlers';
+import { setupHistoryHandlers } from './historyHandlers';
 
 export function setupIPCHandlers(
   configFolder: string,
@@ -43,4 +44,5 @@ export function setupIPCHandlers(
   registerEditHandlers(configFolder);
   setupSettingsHandlers();
   setupSplashHandlers();
+  setupHistoryHandlers(configFolder);
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -6,6 +6,7 @@ import {
   AppSettings,
   IconProgress,
   WindowPinMode,
+  SearchHistoryEntry,
 } from '../common/types';
 
 interface RegisterItem {
@@ -29,7 +30,7 @@ interface DeleteItemRequest {
 contextBridge.exposeInMainWorld('electronAPI', {
   getConfigFolder: () => ipcRenderer.invoke('get-config-folder'),
   loadDataFiles: () => ipcRenderer.invoke('load-data-files'),
-  openItem: (item: LauncherItem) => ipcRenderer.invoke('open-item', item),
+  openItem: (item: LauncherItem, searchQuery?: string) => ipcRenderer.invoke('open-item', item, searchQuery),
   openParentFolder: (item: LauncherItem) => ipcRenderer.invoke('open-parent-folder', item),
   openConfigFolder: () => ipcRenderer.invoke('open-config-folder'),
   openDataFile: () => ipcRenderer.invoke('open-data-file'),
@@ -114,4 +115,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('delete-custom-icon', customIconFileName),
   getCustomIcon: (customIconFileName: string) =>
     ipcRenderer.invoke('get-custom-icon', customIconFileName),
+  // 検索履歴関連API
+  loadSearchHistory: () => ipcRenderer.invoke('load-search-history'),
+  saveSearchHistory: (entries: SearchHistoryEntry[]) => ipcRenderer.invoke('save-search-history', entries),
+  addSearchHistoryEntry: (query: string) => ipcRenderer.invoke('add-search-history-entry', query),
+  clearSearchHistory: () => ipcRenderer.invoke('clear-search-history'),
 });

--- a/src/main/services/searchHistoryService.ts
+++ b/src/main/services/searchHistoryService.ts
@@ -1,0 +1,86 @@
+import * as path from 'path';
+import { FileUtils } from '@common/utils/fileUtils';
+import { SearchHistoryEntry } from '@common/types';
+
+/**
+ * 検索履歴の管理サービス
+ * CSV形式での履歴ファイルの読み書きと履歴データの操作を提供する
+ */
+export class SearchHistoryService {
+  private readonly historyFilePath: string;
+  private readonly maxHistoryCount = 100;
+
+  constructor(configFolder: string) {
+    this.historyFilePath = path.join(configFolder, 'history.txt');
+  }
+
+  /**
+   * 履歴ファイルから検索履歴を読み込む
+   * @returns 検索履歴のエントリー配列（最新が先頭）
+   */
+  loadHistory(): SearchHistoryEntry[] {
+    const content = FileUtils.safeReadTextFile(this.historyFilePath);
+    if (!content) {
+      return [];
+    }
+
+    const entries: SearchHistoryEntry[] = [];
+    const lines = content.split(/\r?\n/);
+
+    for (const line of lines) {
+      const trimmedLine = line.trim();
+      if (!trimmedLine) continue;
+
+      const [query, timestamp] = trimmedLine.split(',');
+      if (query && timestamp) {
+        entries.push({ query: query.trim(), timestamp: timestamp.trim() });
+      }
+    }
+
+    // 最新が先頭になるようにソート
+    return entries.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+  }
+
+  /**
+   * 検索履歴を履歴ファイルに保存する
+   * @param entries 保存する検索履歴のエントリー配列
+   */
+  saveHistory(entries: SearchHistoryEntry[]): void {
+    // 最新が先頭になるようにソートしてから上限まで制限
+    const sortedEntries = entries
+      .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+      .slice(0, this.maxHistoryCount);
+
+    const lines = sortedEntries.map(entry => `${entry.query},${entry.timestamp}`);
+    const content = lines.join('\r\n');
+
+    FileUtils.safeWriteTextFile(this.historyFilePath, content);
+  }
+
+  /**
+   * 新しい検索履歴エントリーを追加する
+   * 既存の同一クエリがある場合は、最新の実行時間で更新する
+   * @param query 検索クエリ
+   */
+  addHistoryEntry(query: string): void {
+    if (!query.trim()) return;
+
+    const entries = this.loadHistory();
+    const timestamp = new Date().toISOString();
+
+    // 既存の同一クエリを削除
+    const filteredEntries = entries.filter(entry => entry.query !== query.trim());
+
+    // 新しいエントリーを先頭に追加
+    filteredEntries.unshift({ query: query.trim(), timestamp });
+
+    this.saveHistory(filteredEntries);
+  }
+
+  /**
+   * 検索履歴をクリアする
+   */
+  clearHistory(): void {
+    this.saveHistory([]);
+  }
+}

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -6,6 +6,7 @@ import {
   AppSettings,
   IconProgress,
   WindowPinMode,
+  SearchHistoryEntry,
 } from '../common/types';
 
 import { RegisterItem } from './components/RegisterModal';
@@ -13,7 +14,7 @@ import { RegisterItem } from './components/RegisterModal';
 export interface ElectronAPI {
   getConfigFolder: () => Promise<string>;
   loadDataFiles: () => Promise<DataFile[]>;
-  openItem: (item: LauncherItem) => Promise<void>;
+  openItem: (item: LauncherItem, searchQuery?: string) => Promise<void>;
   openParentFolder: (item: LauncherItem) => Promise<void>;
   openConfigFolder: () => Promise<void>;
   openDataFile: () => Promise<void>;
@@ -90,6 +91,11 @@ export interface ElectronAPI {
   getCustomIcon: (customIconFileName: string) => Promise<string | null>;
   // スプラッシュスクリーン関連API
   splashReady: () => Promise<boolean>;
+  // 検索履歴関連API
+  loadSearchHistory: () => Promise<SearchHistoryEntry[]>;
+  saveSearchHistory: (entries: SearchHistoryEntry[]) => Promise<void>;
+  addSearchHistoryEntry: (query: string) => Promise<void>;
+  clearSearchHistory: () => Promise<void>;
 }
 
 declare global {

--- a/src/renderer/hooks/useSearchHistory.ts
+++ b/src/renderer/hooks/useSearchHistory.ts
@@ -1,0 +1,126 @@
+import { useState, useEffect, useCallback } from 'react';
+import { SearchHistoryEntry, SearchHistoryState } from '@common/types';
+
+/**
+ * 検索履歴の管理を行うカスタムフック
+ * キーボードナビゲーションでの履歴巡回機能を提供する
+ */
+export function useSearchHistory() {
+  const [historyState, setHistoryState] = useState<SearchHistoryState>({
+    entries: [],
+    currentIndex: -1,
+  });
+
+  // 検索履歴をロードする
+  const loadHistory = useCallback(async () => {
+    try {
+      const entries = await window.electronAPI.loadSearchHistory();
+      setHistoryState(prevState => ({
+        ...prevState,
+        entries,
+        currentIndex: -1, // 履歴ナビゲーションをリセット
+      }));
+    } catch (error) {
+      console.error('検索履歴の読み込みに失敗しました:', error);
+    }
+  }, []);
+
+  // 初回ロード
+  useEffect(() => {
+    loadHistory();
+  }, [loadHistory]);
+
+  // 前の履歴項目に移動（Ctrl + ↑）
+  const navigateToPrevious = useCallback((): string | null => {
+    setHistoryState(prevState => {
+      if (prevState.entries.length === 0) return prevState;
+
+      const newIndex = prevState.currentIndex < prevState.entries.length - 1
+        ? prevState.currentIndex + 1
+        : prevState.entries.length - 1;
+
+      return {
+        ...prevState,
+        currentIndex: newIndex,
+      };
+    });
+
+    // 現在の履歴エントリーのクエリを返す
+    const currentEntry = historyState.entries[historyState.currentIndex >= 0 
+      ? Math.min(historyState.currentIndex + 1, historyState.entries.length - 1)
+      : 0];
+    
+    return currentEntry?.query || null;
+  }, [historyState.entries, historyState.currentIndex]);
+
+  // 次の履歴項目に移動（Ctrl + ↓）
+  const navigateToNext = useCallback((): string | null => {
+    setHistoryState(prevState => {
+      if (prevState.entries.length === 0 || prevState.currentIndex <= 0) {
+        return {
+          ...prevState,
+          currentIndex: -1, // 履歴ナビゲーションを終了
+        };
+      }
+
+      const newIndex = prevState.currentIndex - 1;
+      return {
+        ...prevState,
+        currentIndex: newIndex,
+      };
+    });
+
+    // 現在の履歴エントリーのクエリを返す（または空文字列）
+    const newIndex = historyState.currentIndex - 1;
+    if (newIndex < 0) {
+      return ''; // 履歴から抜ける場合は空文字列を返す
+    }
+
+    const currentEntry = historyState.entries[newIndex];
+    return currentEntry?.query || null;
+  }, [historyState.entries, historyState.currentIndex]);
+
+  // 履歴ナビゲーションをリセット
+  const resetNavigation = useCallback(() => {
+    setHistoryState(prevState => ({
+      ...prevState,
+      currentIndex: -1,
+    }));
+  }, []);
+
+  // 新しい検索履歴エントリーを追加
+  const addHistoryEntry = useCallback(async (query: string) => {
+    if (!query.trim()) return;
+
+    try {
+      await window.electronAPI.addSearchHistoryEntry(query);
+      // 履歴を再ロードしてUIを更新
+      await loadHistory();
+    } catch (error) {
+      console.error('検索履歴の追加に失敗しました:', error);
+    }
+  }, [loadHistory]);
+
+  // 検索履歴をクリア
+  const clearHistory = useCallback(async () => {
+    try {
+      await window.electronAPI.clearSearchHistory();
+      setHistoryState({
+        entries: [],
+        currentIndex: -1,
+      });
+    } catch (error) {
+      console.error('検索履歴のクリアに失敗しました:', error);
+    }
+  }, []);
+
+  return {
+    historyState,
+    navigateToPrevious,
+    navigateToNext,
+    resetNavigation,
+    addHistoryEntry,
+    clearHistory,
+    loadHistory,
+  };
+}


### PR DESCRIPTION
Linuxコマンドライン風の検索履歴機能を実装しました。

## 主な変更点
- Ctrl + 上下矢印キーで履歴をナビゲート
- 最大100件の履歴をCSV形式で永続化
- 重複クエリは最新の実行時間で更新
- 既存の上下矢印キーによるメニュー選択機能は維持

Closes #50

Generated with [Claude Code](https://claude.ai/code)