### PR TITLE
feat: タスクトレイメニューを拡充

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -63,7 +63,7 @@ app.whenReady().then(async () => {
   await createWindow();
 
   // システムトレイアイコンとコンテキストメニューを作成
-  createTray();
+  await createTray();
 
   // テスト環境の場合、ウィンドウを自動表示
   if (process.env.SHOW_WINDOW_ON_STARTUP === '1') {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -335,7 +335,6 @@ const App: React.FC = () => {
     setWindowPinMode(newPinMode);
   };
 
-
   const handleCopyPath = async (item: LauncherItem) => {
     try {
       // 引数がある場合は結合してコピー


### PR DESCRIPTION
タスクトレイメニューに以下の機能を追加しました：
- バージョン情報の表示（v0.2.8）
- ホットキー表示付きの「表示」メニュー
- 設定画面を開く「設定...」メニュー
- データフォルダを開く機能
- GitHubリポジトリへのヘルプリンク

変更内容：
- windowManager.ts: createTray()をasync化し、メニュー項目を拡張
- main.ts: createTray()のawait呼び出しに対応
- shell.openPath()でフォルダを開く機能を実装
- shell.openExternal()でヘルプURLを開く機能を実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)