### PR TITLE
fix: Ctrl+Eで管理ウィンドウが一瞬表示されてすぐ閉じる問題を修正

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -207,6 +207,7 @@ const App: React.FC = () => {
       case 'e':
         if (e.ctrlKey) {
           e.preventDefault();
+          e.stopPropagation();
           window.electronAPI.toggleEditWindow();
         }
         break;


### PR DESCRIPTION
イベントバブルアップにより toggleEditWindow() が2回呼ばれていたため、
e.stopPropagation() を追加してイベント伝播を防止。

🤖 Generated with [Claude Code](https://claude.com/claude-code)