### PR TITLE
feat: グループアイテムの右クリックメニューから編集機能を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "quick-dash-launcher",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quick-dash-launcher",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
+      "os": [
+        "win32"
+      ],
       "dependencies": {
         "@types/minimatch": "^5.1.2",
         "electron-store": "^10.1.0",
@@ -53,6 +56,9 @@
         "vite-plugin-electron-renderer": "^0.14.6",
         "vitest": "^3.2.4",
         "wait-on": "^8.0.3"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -609,9 +609,23 @@ const App: React.FC = () => {
     openRegisterModal();
   };
 
-  const handleEditItem = async (item: LauncherItem) => {
+  const handleEditItem = async (item: AppItem) => {
+    // グループアイテムの場合
+    if (item.type === 'group') {
+      const groupItem = item as GroupItem;
+      const rawDataLine: RawDataLine = {
+        lineNumber: groupItem.lineNumber || 1,
+        content: `group,${groupItem.name},${groupItem.itemNames.join(',')}`,
+        type: 'directive',
+        sourceFile: groupItem.sourceFile || 'data.txt',
+        customIcon: undefined,
+      };
+      openEditModal(rawDataLine);
+      return;
+    }
+
     // LauncherItemからRawDataLineを構築
-    const rawDataLine: RawDataLine = await convertLauncherItemToRawDataLine(item);
+    const rawDataLine: RawDataLine = await convertLauncherItemToRawDataLine(item as LauncherItem);
     openEditModal(rawDataLine);
   };
 

--- a/src/renderer/components/ContextMenu.tsx
+++ b/src/renderer/components/ContextMenu.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useRef } from 'react';
 import { PathUtils } from '@common/utils/pathUtils';
 
-import { LauncherItem } from '../../common/types';
+import { AppItem, LauncherItem } from '../../common/types';
 
 interface ContextMenuProps {
   isVisible: boolean;
   position: { x: number; y: number };
-  item: LauncherItem | null;
+  item: AppItem | null;
   onClose: () => void;
   onCopyPath: (item: LauncherItem) => void;
   onCopyParentPath: (item: LauncherItem) => void;
@@ -14,7 +14,7 @@ interface ContextMenuProps {
   onCopyShortcutPath?: (item: LauncherItem) => void;
   onCopyShortcutParentPath?: (item: LauncherItem) => void;
   onOpenShortcutParentFolder?: (item: LauncherItem) => void;
-  onEditItem?: (item: LauncherItem) => void | Promise<void>;
+  onEditItem?: (item: AppItem) => void | Promise<void>;
 }
 
 const ContextMenu: React.FC<ContextMenuProps> = ({
@@ -57,43 +57,43 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
   }, [isVisible, onClose]);
 
   const handleCopyPath = () => {
-    if (item) {
-      onCopyPath(item);
+    if (item && item.type !== 'group') {
+      onCopyPath(item as LauncherItem);
       onClose();
     }
   };
 
   const handleCopyParentPath = () => {
-    if (item) {
-      onCopyParentPath(item);
+    if (item && item.type !== 'group') {
+      onCopyParentPath(item as LauncherItem);
       onClose();
     }
   };
 
   const handleCopyShortcutPath = () => {
-    if (item && onCopyShortcutPath) {
-      onCopyShortcutPath(item);
+    if (item && item.type !== 'group' && onCopyShortcutPath) {
+      onCopyShortcutPath(item as LauncherItem);
       onClose();
     }
   };
 
   const handleCopyShortcutParentPath = () => {
-    if (item && onCopyShortcutParentPath) {
-      onCopyShortcutParentPath(item);
+    if (item && item.type !== 'group' && onCopyShortcutParentPath) {
+      onCopyShortcutParentPath(item as LauncherItem);
       onClose();
     }
   };
 
   const handleOpenParentFolder = () => {
-    if (item) {
-      onOpenParentFolder(item);
+    if (item && item.type !== 'group') {
+      onOpenParentFolder(item as LauncherItem);
       onClose();
     }
   };
 
   const handleOpenShortcutParentFolder = () => {
-    if (item && onOpenShortcutParentFolder) {
-      onOpenShortcutParentFolder(item);
+    if (item && item.type !== 'group' && onOpenShortcutParentFolder) {
+      onOpenShortcutParentFolder(item as LauncherItem);
       onClose();
     }
   };
@@ -105,31 +105,40 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
     }
   };
 
+  // グループアイテムかどうかを判定
+  const isGroupItem = item?.type === 'group';
+
   // ショートカットアイテムかどうかを判定
-  const isShortcutItem = item ? PathUtils.isShortcutItem(item) : false;
+  const isShortcutItem =
+    item && item.type !== 'group' ? PathUtils.isShortcutItem(item as LauncherItem) : false;
 
   // パスを取得するヘルパー関数
   const getFullPath = (): string => {
-    return item ? PathUtils.getFullPath(item) : '';
+    return item && item.type !== 'group' ? PathUtils.getFullPath(item as LauncherItem) : '';
   };
 
   const getParentPath = (): string => {
-    return item ? PathUtils.getParentPath(item.path) : '';
+    return item && item.type !== 'group' && 'path' in item
+      ? PathUtils.getParentPath(item.path)
+      : '';
   };
 
   const getShortcutPath = (): string => {
-    return item?.originalPath || '';
+    return item && item.type !== 'group' && 'originalPath' in item ? item.originalPath || '' : '';
   };
 
   const getShortcutParentPath = (): string => {
-    return item?.originalPath ? PathUtils.getParentPath(item.originalPath) : '';
+    return item && item.type !== 'group' && 'originalPath' in item && item.originalPath
+      ? PathUtils.getParentPath(item.originalPath)
+      : '';
   };
 
   const getAdjustedPosition = () => {
     const menuWidth = 200;
-    // メニュー項目数に応じて高さを調整（編集+基本3項目 + ショートカットで+3項目 + 区切り線2本）
+    // グループアイテムの場合は編集メニューのみ（高さ60px）
+    // 通常アイテムの場合：編集+基本3項目 + ショートカットで+3項目 + 区切り線2本
     const baseHeight = onEditItem ? 200 : 160;
-    const menuHeight = isShortcutItem ? baseHeight + 140 : baseHeight;
+    const menuHeight = isGroupItem ? 60 : isShortcutItem ? baseHeight + 140 : baseHeight;
 
     let adjustedX = position.x;
     let adjustedY = position.y;
@@ -152,7 +161,8 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
   const adjustedPosition = getAdjustedPosition();
 
   // URLやカスタムURIには親フォルダーが存在しない
-  const hasParentFolder = item?.type !== 'url' && item?.type !== 'customUri';
+  const hasParentFolder =
+    item?.type !== 'url' && item?.type !== 'customUri' && item?.type !== 'group';
 
   return (
     <div
@@ -171,61 +181,69 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
             <span className="context-menu-icon">✏️</span>
             <span>編集</span>
           </div>
-          <div className="context-menu-divider" />
+          {!isGroupItem && <div className="context-menu-divider" />}
         </>
       )}
-      <div className="context-menu-item" onClick={handleCopyPath} title={getFullPath()}>
-        <span className="context-menu-icon">📋</span>
-        <span>パスをコピー</span>
-      </div>
-      {hasParentFolder && (
+      {!isGroupItem && (
         <>
-          <div className="context-menu-item" onClick={handleCopyParentPath} title={getParentPath()}>
+          <div className="context-menu-item" onClick={handleCopyPath} title={getFullPath()}>
             <span className="context-menu-icon">📋</span>
-            <span>親フォルダーのパスをコピー</span>
+            <span>パスをコピー</span>
           </div>
-          <div
-            className="context-menu-item"
-            onClick={handleOpenParentFolder}
-            title={getParentPath()}
-          >
-            <span className="context-menu-icon">📂</span>
-            <span>親フォルダーを開く</span>
-          </div>
-        </>
-      )}
-      {isShortcutItem && (
-        <>
-          <div className="context-menu-divider" />
-          {onCopyShortcutPath && (
-            <div
-              className="context-menu-item"
-              onClick={handleCopyShortcutPath}
-              title={getShortcutPath()}
-            >
-              <span className="context-menu-icon">📋</span>
-              <span>リンク先のパスをコピー</span>
-            </div>
+          {hasParentFolder && (
+            <>
+              <div
+                className="context-menu-item"
+                onClick={handleCopyParentPath}
+                title={getParentPath()}
+              >
+                <span className="context-menu-icon">📋</span>
+                <span>親フォルダーのパスをコピー</span>
+              </div>
+              <div
+                className="context-menu-item"
+                onClick={handleOpenParentFolder}
+                title={getParentPath()}
+              >
+                <span className="context-menu-icon">📂</span>
+                <span>親フォルダーを開く</span>
+              </div>
+            </>
           )}
-          {onCopyShortcutParentPath && (
-            <div
-              className="context-menu-item"
-              onClick={handleCopyShortcutParentPath}
-              title={getShortcutParentPath()}
-            >
-              <span className="context-menu-icon">📋</span>
-              <span>リンク先の親フォルダーのパスをコピー</span>
-            </div>
-          )}
-          {onOpenShortcutParentFolder && (
-            <div
-              className="context-menu-item"
-              onClick={handleOpenShortcutParentFolder}
-              title={getShortcutParentPath()}
-            >
-              <span className="context-menu-icon">📂</span>
-              <span>リンク先の親フォルダーを開く</span>
-            </div>
+          {isShortcutItem && (
+            <>
+              <div className="context-menu-divider" />
+              {onCopyShortcutPath && (
+                <div
+                  className="context-menu-item"
+                  onClick={handleCopyShortcutPath}
+                  title={getShortcutPath()}
+                >
+                  <span className="context-menu-icon">📋</span>
+                  <span>リンク先のパスをコピー</span>
+                </div>
+              )}
+              {onCopyShortcutParentPath && (
+                <div
+                  className="context-menu-item"
+                  onClick={handleCopyShortcutParentPath}
+                  title={getShortcutParentPath()}
+                >
+                  <span className="context-menu-icon">📋</span>
+                  <span>リンク先の親フォルダーのパスをコピー</span>
+                </div>
+              )}
+              {onOpenShortcutParentFolder && (
+                <div
+                  className="context-menu-item"
+                  onClick={handleOpenShortcutParentFolder}
+                  title={getShortcutParentPath()}
+                >
+                  <span className="context-menu-icon">📂</span>
+                  <span>リンク先の親フォルダーを開く</span>
+                </div>
+              )}
+            </>
           )}
         </>
       )}

--- a/src/renderer/components/ItemList.tsx
+++ b/src/renderer/components/ItemList.tsx
@@ -17,7 +17,7 @@ interface ItemListProps {
   onCopyShortcutPath?: (item: LauncherItem) => void;
   onCopyShortcutParentPath?: (item: LauncherItem) => void;
   onOpenShortcutParentFolder?: (item: LauncherItem) => void;
-  onEditItem?: (item: LauncherItem) => void | Promise<void>;
+  onEditItem?: (item: AppItem) => void | Promise<void>;
 }
 
 const ItemList: React.FC<ItemListProps> = ({
@@ -39,7 +39,7 @@ const ItemList: React.FC<ItemListProps> = ({
   const [contextMenu, setContextMenu] = useState<{
     isVisible: boolean;
     position: { x: number; y: number };
-    item: LauncherItem | null;
+    item: AppItem | null;
   }>({
     isVisible: false,
     position: { x: 0, y: 0 },
@@ -133,15 +133,10 @@ const ItemList: React.FC<ItemListProps> = ({
     event.preventDefault();
     event.stopPropagation();
 
-    // グループアイテムの場合はコンテキストメニューを表示しない
-    if (item.type === 'group') {
-      return;
-    }
-
     setContextMenu({
       isVisible: true,
       position: { x: event.clientX, y: event.clientY },
-      item: item as LauncherItem,
+      item: item,
     });
   };
 


### PR DESCRIPTION
## Summary
- グループアイテムを右クリックすると編集メニューが表示されるように変更
- グループアイテムの場合は編集メニューのみを表示し、パス関連メニューは非表示
- handleEditItem関数をAppItem型対応に修正し、グループアイテムを正しく処理

## Changes
- `src/renderer/App.tsx`: handleEditItem関数をAppItem型対応に変更
- `src/renderer/components/ContextMenu.tsx`: グループアイテム対応とメニュー表示制御、型ガード追加
- `src/renderer/components/ItemList.tsx`: グループアイテムのコンテキストメニュー表示を有効化

## Test plan
- [x] グループアイテムを右クリックして編集メニューが表示されることを確認
- [x] 編集メニューをクリックして正しくグループアイテムとして編集できることを確認
- [x] ビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)