### PR TITLE
test: 初回起動時の設定保存機能のE2Eテスト追加と修正

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -705,7 +705,8 @@ const App: React.FC = () => {
     try {
       // ホットキーを設定（設定ファイルが自動的に作成される）
       await window.electronAPI.setMultipleSettings({
-        hotkey,
+        globalHotkey: hotkey,
+        isFirstLaunch: false,
       });
       await window.electronAPI.changeHotkey(hotkey);
 


### PR DESCRIPTION
## 概要
初回起動完了時にsettings.jsonへ正しく設定が保存されることを検証するE2Eテストを追加しました。

## 変更内容

### 修正
- **App.tsx**: 初回起動完了ハンドラで設定キーを`hotkey`から`globalHotkey`に修正
- **App.tsx**: `isFirstLaunch: false`フラグを明示的に設定するように修正

### テスト追加
**first-launch-setup.spec.ts** に以下の3つのテストケースを追加：

1. **完了ボタンをクリックするとsettings.jsonに設定が保存される**
   - 完了ボタンクリック前後でsettings.jsonの状態を検証
   - `globalHotkey`と`isFirstLaunch`が正しく保存されることを確認

2. **完了ボタンをクリックすると設定ファイルに正しい内容が保存される**
   - デフォルトホットキー（Alt+Space）が保存されることを確認
   - `isFirstLaunch`フラグが`false`に設定されることを確認

3. **ホットキーを変更してから完了ボタンをクリックすると変更内容が保存される**
   - カスタムホットキー（Ctrl+Shift+A）入力をシミュレート
   - 変更したホットキーが正しく保存されることを確認

## テスト結果
```
✓ 9 passed (19.6s)
```

すべてのテストが成功しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)