### PR TITLE
refactor: データファイルタブのマイグレーション処理を削除

### DIFF
--- a/src/main/services/settingsService.ts
+++ b/src/main/services/settingsService.ts
@@ -150,34 +150,7 @@ export class SettingsService {
     await this.initializeStore();
     if (!this.store) throw new Error('Store not initialized');
     try {
-      const settings = this.store.store as AppSettings;
-
-      // マイグレーション: 旧形式（file: string）を新形式（files: string[]）に変換
-      if (settings.dataFileTabs && settings.dataFileTabs.length > 0) {
-        const needsMigration = settings.dataFileTabs.some(
-          (tab: any) => 'file' in tab && !('files' in tab)
-        );
-
-        if (needsMigration) {
-          logger.info('Migrating dataFileTabs from old format to new format');
-          const migratedTabs = settings.dataFileTabs.map((tab: any) => {
-            if ('file' in tab && !('files' in tab)) {
-              return {
-                files: [tab.file],
-                name: tab.name,
-                defaultFile: tab.file,
-              };
-            }
-            return tab;
-          });
-
-          settings.dataFileTabs = migratedTabs;
-          await this.setMultiple({ dataFileTabs: migratedTabs });
-          logger.info('Settings migrated successfully');
-        }
-      }
-
-      return settings;
+      return this.store.store as AppSettings;
     } catch (error) {
       logger.error('Failed to get all settings:', error);
       return SettingsService.DEFAULT_SETTINGS;


### PR DESCRIPTION
## 概要
後方互換性が不要なため、設定サービスからマイグレーション処理を削除しました。

## 変更内容
- `SettingsService.getAll()` メソッドからデータファイルタブのマイグレーション処理を削除
- 旧形式 `{ file: string }` から新形式 `{ files: string[] }` への変換ロジックを削除
- getAll()メソッドを簡素化（28行→1行）

## 理由
- 後方互換性が不要
- 型定義は既に新形式のみをサポート
- コードの簡素化

🤖 Generated with [Claude Code](https://claude.com/claude-code)