### PR TITLE
fix: 1つのタブに複数ファイルを紐づけた場合のタブ重複表示を修正

### DIFF
--- a/tests/e2e/templates/with-multi-file-tabs/data.txt
+++ b/tests/e2e/templates/with-multi-file-tabs/data.txt
@@ -1,0 +1,15 @@
+// 基本テンプレート - 標準的なアイテムセット
+// このファイルはテストで基本的なアイテムセットが必要な場合に使用
+
+// Webサイト
+GitHub,https://github.com/
+Google,https://google.com/
+Wikipedia,https://wikipedia.org/
+
+// アプリケーション
+メモ帳,notepad.exe
+電卓,calc.exe
+
+// フォルダ
+デスクトップ,shell:Desktop
+ドキュメント,shell:Documents

--- a/tests/e2e/templates/with-multi-file-tabs/data2.txt
+++ b/tests/e2e/templates/with-multi-file-tabs/data2.txt
@@ -1,0 +1,11 @@
+// data2.txt用基本テンプレート - サブタブのテストデータ
+// サブタブ機能のテストで使用
+
+// Webサイト（サブタブ用）
+Stack Overflow,https://stackoverflow.com/
+Reddit,https://reddit.com/
+YouTube,https://youtube.com/
+
+// アプリケーション（サブタブ用）
+ペイント,mspaint.exe
+エクスプローラー,explorer.exe

--- a/tests/e2e/templates/with-multi-file-tabs/data3.txt
+++ b/tests/e2e/templates/with-multi-file-tabs/data3.txt
@@ -1,0 +1,4 @@
+# data3.txt用のアイテム
+Qiita,https://qiita.com
+Zenn,https://zenn.dev
+note,https://note.com

--- a/tests/e2e/templates/with-multi-file-tabs/settings.json
+++ b/tests/e2e/templates/with-multi-file-tabs/settings.json
@@ -1,0 +1,26 @@
+{
+	"hotkey": "Alt+Space",
+	"windowWidth": 600,
+	"windowHeight": 400,
+	"editModeWidth": 1200,
+	"editModeHeight": 700,
+	"autoLaunch": false,
+	"backupEnabled": false,
+	"backupOnStart": false,
+	"backupOnEdit": false,
+	"backupInterval": 5,
+	"backupRetention": 20,
+	"showDataFileTabs": true,
+	"defaultFileTab": "data.txt",
+	"dataFileTabs": [
+		{
+			"files": ["data.txt", "data3.txt"],
+			"name": "統合タブ",
+			"defaultFile": "data.txt"
+		},
+		{
+			"files": ["data2.txt"],
+			"name": "サブ1"
+		}
+	]
+}


### PR DESCRIPTION
## 問題
1つのタブに複数のデータファイルを紐づけた場合、ファイル数分のタブボタンが表示されてしまっていた。

例: `files: ["data.txt", "data3.txt"]` の場合、「メイン」タブが2つ表示される

## 原因
- FileTabBarコンポーネントが `dataFiles` 配列の各ファイルに対してタブボタンを生成していた
- `tabNames` の生成ロジックが各ファイルに同じタブ名をマッピングしていた

## 修正内容

### FileTabBar.tsx
- タブグループ (`dataFileTabs`) ベースの表示に変更
- 各タブグループごとに1つのタブボタンのみ表示
- 複数ファイルを持つタブでも1つのボタンで統合表示
- ツールチップに全ファイル名を表示

### App.tsx
- `dataFiles`, `tabNames`, `getSortedDataFiles()` の使用を削除
- タブ切り替えのキーボードショートカットをタブグループベースに修正
- 表示条件を `dataFileTabs.length > 1` に変更

### E2Eテスト追加
- 新しいテンプレート `with-multi-file-tabs` を作成
- 複数ファイル統合タブの動作を検証する5つのテストを追加
  - タブが1つだけ表示されること
  - 複数ファイルのアイテムが全て表示されること
  - アイテム数が複数ファイルの合計になること
  - タブ切り替え時の動作
  - 検索時の動作

## テスト結果
multi-tab.spec.ts: 22/22 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)