### PR TITLE
feat: グループアイテム編集UIを検索可能なリスト形式に改善

### DIFF
--- a/src/renderer/components/GroupItemSelectorModal.tsx
+++ b/src/renderer/components/GroupItemSelectorModal.tsx
@@ -1,0 +1,191 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { RawDataLine } from '../../common/types';
+import { debugInfo } from '../utils/debug';
+
+interface GroupItemSelectorModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (itemName: string) => void;
+  targetFile: string; // 対象のデータファイル名
+  excludeNames: string[]; // 既に追加済みのアイテム名（選択不可にする）
+}
+
+const GroupItemSelectorModal: React.FC<GroupItemSelectorModalProps> = ({
+  isOpen,
+  onClose,
+  onSelect,
+  targetFile,
+  excludeNames,
+}) => {
+  const [availableItems, setAvailableItems] = useState<string[]>([]);
+  const [filteredItems, setFilteredItems] = useState<string[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const modalRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSearchQuery('');
+      return;
+    }
+
+    // モーダルが開いたときの処理
+    loadAvailableItems();
+
+    // フォーカスをモーダルに設定
+    modalRef.current?.focus();
+    // 検索ボックスにフォーカス
+    setTimeout(() => {
+      searchInputRef.current?.focus();
+    }, 100);
+
+    // キーイベントの制御
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const modal = modalRef.current;
+      if (!modal) return;
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+        onClose();
+        return;
+      }
+
+      // モーダル内でのキーイベントの場合、背景への伝播を完全に阻止
+      const isModalFocused = modal.contains(document.activeElement);
+      if (isModalFocused) {
+        const activeElement = document.activeElement as HTMLElement;
+        const isInputField = activeElement && activeElement.tagName === 'INPUT';
+
+        if (isInputField) {
+          // 入力フィールドでの通常の編集キーは許可
+          if (
+            event.key.length === 1 ||
+            [
+              'Backspace',
+              'Delete',
+              'ArrowLeft',
+              'ArrowRight',
+              'ArrowUp',
+              'ArrowDown',
+              'Home',
+              'End',
+            ].includes(event.key) ||
+            (event.ctrlKey && ['a', 'c', 'v', 'x', 'z', 'y'].includes(event.key))
+          ) {
+            event.stopPropagation();
+            event.stopImmediatePropagation();
+            return;
+          }
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown, true);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, true);
+    };
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    // 検索クエリが変更されたらフィルタリング
+    if (searchQuery.trim() === '') {
+      setFilteredItems(availableItems);
+    } else {
+      const query = searchQuery.toLowerCase();
+      const filtered = availableItems.filter((name) => name.toLowerCase().includes(query));
+      setFilteredItems(filtered);
+    }
+  }, [searchQuery, availableItems]);
+
+  const loadAvailableItems = async () => {
+    try {
+      debugInfo('Loading available items for file:', targetFile);
+      const rawLines: RawDataLine[] = await window.electronAPI.loadRawDataFiles();
+
+      // 対象ファイルのアイテムのみを抽出
+      const itemsInFile = rawLines
+        .filter((line: RawDataLine) => line.sourceFile === targetFile && line.type === 'item')
+        .map((line: RawDataLine) => {
+          // アイテム名を抽出（カンマ区切りの最初の要素）
+          const parts = line.content.split(',');
+          return parts[0]?.trim() || '';
+        })
+        .filter((name: string) => name !== ''); // 空の名前を除外
+
+      debugInfo('Available items:', itemsInFile);
+      setAvailableItems(itemsInFile);
+      setFilteredItems(itemsInFile);
+    } catch (error) {
+      console.error('Error loading available items:', error);
+    }
+  };
+
+  const handleSelectItem = (itemName: string) => {
+    onSelect(itemName);
+    onClose();
+  };
+
+  const isExcluded = (itemName: string) => {
+    return excludeNames.includes(itemName);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal-content group-item-selector-modal"
+        onClick={(e) => e.stopPropagation()}
+        ref={modalRef}
+        tabIndex={-1}
+      >
+        <h3>グループアイテムを選択</h3>
+
+        <div className="search-box">
+          <input
+            ref={searchInputRef}
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="アイテム名で検索..."
+          />
+        </div>
+
+        <div className="item-list">
+          {filteredItems.length === 0 ? (
+            <div className="no-items">
+              {searchQuery ? '検索結果がありません' : 'このファイルにはアイテムがありません'}
+            </div>
+          ) : (
+            filteredItems.map((itemName, index) => {
+              const excluded = isExcluded(itemName);
+              return (
+                <div
+                  key={index}
+                  className={`item-row ${excluded ? 'excluded' : ''}`}
+                  onClick={() => !excluded && handleSelectItem(itemName)}
+                >
+                  <span className="item-name">{itemName}</span>
+                  {excluded && <span className="excluded-label">追加済み</span>}
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        <div className="modal-actions">
+          <button onClick={onClose}>キャンセル</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GroupItemSelectorModal;

--- a/src/renderer/styles/components/GroupItemSelectorModal.css
+++ b/src/renderer/styles/components/GroupItemSelectorModal.css
@@ -1,0 +1,97 @@
+/* GroupItemSelectorModal関連のスタイル */
+.group-item-selector-modal {
+  max-width: 500px;
+  width: 90%;
+  max-height: 600px;
+  display: flex;
+  flex-direction: column;
+  padding: var(--spacing-xl);
+}
+
+.group-item-selector-modal h3 {
+  margin-bottom: var(--spacing-lg);
+  font-size: var(--font-size-xl);
+  color: var(--text-primary);
+}
+
+.search-box {
+  margin-bottom: var(--spacing-md);
+}
+
+.search-box input {
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: var(--border-light);
+  border-radius: var(--border-radius);
+  font-size: var(--font-size-base);
+  transition: border-color var(--transition-fast);
+}
+
+.search-box input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: var(--focus-ring);
+}
+
+.item-list {
+  flex: 1;
+  overflow-y: auto;
+  border: var(--border-light);
+  border-radius: var(--border-radius);
+  background-color: var(--bg-secondary);
+  max-height: 400px;
+}
+
+.item-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-sm) var(--spacing-md);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+  border-bottom: 1px solid var(--color-gray-300);
+}
+
+.item-row:last-child {
+  border-bottom: none;
+}
+
+.item-row:hover:not(.excluded) {
+  background-color: var(--bg-hover);
+}
+
+.item-row.excluded {
+  background-color: var(--bg-disabled);
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.item-name {
+  flex: 1;
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+}
+
+.item-row.excluded .item-name {
+  color: var(--text-disabled);
+}
+
+.excluded-label {
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+  font-style: italic;
+  padding: 2px var(--spacing-xs);
+  background-color: var(--color-gray-400);
+  border-radius: var(--border-radius-sm);
+}
+
+.no-items {
+  padding: var(--spacing-xl);
+  text-align: center;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.group-item-selector-modal .modal-actions {
+  margin-top: var(--spacing-lg);
+}

--- a/src/renderer/styles/components/RegisterModal.css
+++ b/src/renderer/styles/components/RegisterModal.css
@@ -133,6 +133,86 @@
   background-color: var(--color-primary-hover);
 }
 
+/* グループアイテムリスト */
+.group-item-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.group-items {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm);
+  background-color: var(--bg-secondary);
+  border-radius: var(--border-radius);
+  border: var(--border-light);
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.group-item-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background-color: var(--color-white);
+  border-radius: var(--border-radius-sm);
+  border: 1px solid var(--color-gray-300);
+}
+
+.group-item-name {
+  flex: 1;
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.remove-group-item-btn {
+  background: none;
+  border: none;
+  color: var(--color-danger);
+  font-size: var(--font-size-lg);
+  cursor: pointer;
+  padding: 0 var(--spacing-xs);
+  line-height: 1;
+  transition: color var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.remove-group-item-btn:hover {
+  color: var(--color-danger-hover);
+}
+
+.no-group-items {
+  padding: var(--spacing-md);
+  text-align: center;
+  color: var(--text-secondary);
+  font-style: italic;
+  background-color: var(--bg-secondary);
+  border-radius: var(--border-radius);
+  border: var(--border-light);
+}
+
+.add-group-item-btn {
+  background-color: var(--color-primary);
+  color: var(--color-white);
+  border: none;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+  font-size: var(--font-size-sm);
+  align-self: flex-start;
+}
+
+.add-group-item-btn:hover {
+  background-color: var(--color-primary-hover);
+}
+
 /* エラー表示スタイル */
 .form-group input.error,
 .form-group textarea.error {

--- a/src/renderer/styles/index.css
+++ b/src/renderer/styles/index.css
@@ -3,6 +3,7 @@
 @import './common.css';
 @import './components/FileTabBar.css';
 @import './components/ItemCountDisplay.css';
+@import './components/GroupItemSelectorModal.css';
 
 /* グローバルリセットとベーススタイル */
 * {


### PR DESCRIPTION
## 概要
グループアイテムのアイテム名リスト編集UIを、カンマ区切り入力から検索可能なリスト形式に改善しました。

## 主な変更内容

### グループアイテム選択モーダルを新規作成
- 同じファイル内の既存アイテムから選択
- リアルタイム検索機能（部分一致フィルタリング）
- 既に追加済みのアイテムは選択不可（グレーアウト表示）

### RegisterModalのグループアイテム編集UIを改善
- カンマ区切りtextarea → 視覚的なリスト形式に変更
- 各アイテムに削除ボタン（×）を配置
- 「+ アイテムを追加」ボタンでモーダル起動
- 不要なstate管理ロジックを削除して簡素化

### スタイルシート追加
- GroupItemSelectorModal.css: モーダル専用スタイル
- RegisterModal.css: グループアイテムリスト用スタイル
- CSSデザインシステムに準拠（CSS変数使用）

## 改善効果
- ✅ タイプミス防止（既存アイテムからのみ選択）
- ✅ データ整合性向上（存在しないアイテム名の入力を防止）
- ✅ ユーザビリティ向上（検索、視覚的なリスト表示）
- ✅ 重複追加防止（既に追加済みは選択不可）

## スクリーンショット
（必要に応じて追加してください）

## テスト
- [x] ビルド成功確認
- [x] 型チェック（新規コードのエラーなし）
- [ ] 手動動作確認（`npm run dev`で確認可能）

🤖 Generated with [Claude Code](https://claude.com/claude-code)