### PR TITLE
fix: コンテキストメニューの区切り線を明確に表示 (#69)

### DIFF
--- a/src/renderer/styles/components/ContextMenu.css
+++ b/src/renderer/styles/components/ContextMenu.css
@@ -40,6 +40,6 @@
 
 .context-menu-divider {
   height: 1px;
-  background-color: var(--border-color);
-  margin: var(--spacing-xs) 0;
+  background-color: var(--color-gray-400);
+  margin: var(--spacing-sm) 0;
 }


### PR DESCRIPTION
## Summary

コンテキストメニューの区切り線が視覚的に見えにくい問題を修正しました。

- 未定義のCSS変数 `var(--border-color)` を使用していたため、区切り線が表示されていなかった
- 既存のCSS変数 `var(--color-gray-400)` (#e0e0e0) を使用して明確な区切り線を実現
- 区切り線の上下マージンを4px→8pxに拡大して視認性を向上

## 変更ファイル

- `src/renderer/styles/components/ContextMenu.css`

## Closes

#69

🤖 Generated with [Claude Code](https://claude.com/claude-code)