### PR TITLE
fix: メインウィンドウリサイズ時の下部空白表示を修正 (#72)

### DIFF
--- a/src/renderer/styles/components/ItemList.css
+++ b/src/renderer/styles/components/ItemList.css
@@ -1,6 +1,9 @@
 /* アイテムリスト関連のスタイル */
 .item-list {
-  flex: 1;
+  flex: 1 1 0;
+  min-height: 0;
+  max-height: none;
+  height: auto;
   overflow-y: auto;
   padding: var(--spacing-xs);
 }

--- a/src/renderer/styles/index.css
+++ b/src/renderer/styles/index.css
@@ -12,19 +12,29 @@
   padding: 0;
 }
 
+html {
+  overflow: hidden;
+}
+
 body {
   font-family: var(--font-family);
   font-size: var(--font-size-base);
   background-color: var(--bg-body);
   overflow: hidden;
   user-select: none;
+  margin: 0;
 }
 
 .app {
-  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
   display: flex;
   flex-direction: column;
   background-color: var(--bg-app);
+  overflow: hidden;
 }
 
 /* Scrollbar styling */


### PR DESCRIPTION
## Summary
メインウィンドウを下に広げた際、ウィンドウ下部に空白が表示される問題（Issue #72）を修正しました。

## Changes
- `.app` を `position: fixed` に変更し、ウィンドウ全体に確実に固定
- `.item-list` に `flex: 1 1 0` と `min-height: 0` を設定し、Flexboxの縮小動作を有効化
- `max-height` と `height` プロパティでサイズ制約を解除

これにより、ウィンドウをリサイズした際もコンテンツが正しく追従するようになりました。

## Modified Files
- `src/renderer/styles/index.css`
- `src/renderer/styles/components/ItemList.css`

## Test plan
- [x] アプリケーションを起動
- [x] メインウィンドウを下方向に広げる
- [x] ウィンドウ下部に空白が表示されないことを確認
- [x] ウィンドウを縮小しても正しく動作することを確認

## Quality Check
- [x] TypeScript型チェック合格
- [x] ESLint合格
- [x] コード品質チェック合格（⭐⭐⭐⭐⭐ 5/5）

🤖 Generated with [Claude Code](https://claude.com/claude-code)