### PR TITLE
fix: ファイル管理モーダルの背景透過問題を修正

### DIFF
--- a/src/renderer/styles/components/AdminWindow.css
+++ b/src/renderer/styles/components/AdminWindow.css
@@ -1230,29 +1230,7 @@
 }
 
 /* ファイル管理モーダル */
-.modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-}
-
-.modal-content {
-  background-color: var(--bg-primary);
-  border-radius: var(--border-radius-xl);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
-  max-width: 600px;
-  width: 90%;
-  max-height: 80vh;
-  display: flex;
-  flex-direction: column;
-}
+/* .modal-overlay と .modal-content は Modal.css で定義されています */
 
 .modal-header {
   display: flex;


### PR DESCRIPTION
## Summary
- AdminWindow.cssとModal.cssで`.modal-overlay`と`.modal-content`が重複定義されていた問題を修正
- AdminWindow.cssから重複定義を削除し、Modal.cssの定義を使用するように統一
- モーダル背景が正しく表示されるようになり、半透明の黒背景とぼかし効果が適用される

## Test plan
- [ ] 開発モードでアプリを起動 (`npm run dev`)
- [ ] 設定タブを開く
- [ ] タブ管理セクションで「📁 ファイル管理」ボタンをクリックしてモーダルを表示
- [ ] モーダル背景が半透明の黒色（`rgba(0, 0, 0, 0.5)`）で表示されることを確認
- [ ] 背景にぼかし効果が適用されていることを確認
- [ ] モーダルが正しいz-index(2000)で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)