### PR TITLE
test: カスタムConfirmDialogに対応したE2Eテストに修正

### DIFF
--- a/tests/e2e/specs/item-management.spec.ts
+++ b/tests/e2e/specs/item-management.spec.ts
@@ -276,10 +276,20 @@ test.describe('QuickDashLauncher - アイテム管理機能テスト', () => {
         const githubRow = adminWindow.locator('.raw-item-row', { hasText: 'GitHub' });
         const deleteButton = githubRow.locator('button.delete-button');
 
-        // confirmダイアログを受け入れる
-        adminWindow.on('dialog', (dialog) => dialog.accept());
+        // 削除ボタンをクリック（カスタムConfirmDialogが表示される）
         await deleteButton.click();
         await adminUtils.wait(300);
+
+        // カスタムConfirmDialogの確認ボタンをクリック
+        const confirmButton = adminWindow.locator('[data-testid="confirm-dialog-confirm-button"]');
+        await expect(confirmButton).toBeVisible();
+        await confirmButton.click();
+        await adminUtils.wait(300);
+
+        // ダイアログが閉じたことを確認
+        const confirmDialog = adminWindow.locator('.confirm-dialog');
+        await expect(confirmDialog).not.toBeVisible();
+
         await adminUtils.attachScreenshot(testInfo, '削除後');
 
         // GitHubアイテムが表示されなくなったことを確認
@@ -330,10 +340,20 @@ test.describe('QuickDashLauncher - アイテム管理機能テスト', () => {
       await test.step('選択したアイテムを削除ボタンをクリック', async () => {
         const deleteSelectedButton = adminWindow.locator('button.delete-lines-button');
 
-        // confirmダイアログを受け入れる
-        adminWindow.on('dialog', (dialog) => dialog.accept());
+        // 削除ボタンをクリック（カスタムConfirmDialogが表示される）
         await deleteSelectedButton.click();
         await adminUtils.wait(300);
+
+        // カスタムConfirmDialogの確認ボタンをクリック
+        const confirmButton = adminWindow.locator('[data-testid="confirm-dialog-confirm-button"]');
+        await expect(confirmButton).toBeVisible();
+        await confirmButton.click();
+        await adminUtils.wait(300);
+
+        // ダイアログが閉じたことを確認
+        const confirmDialog = adminWindow.locator('.confirm-dialog');
+        await expect(confirmDialog).not.toBeVisible();
+
         await adminUtils.attachScreenshot(testInfo, '一括削除後');
 
         // アイテムが削除されたことを確認
@@ -380,10 +400,20 @@ test.describe('QuickDashLauncher - アイテム管理機能テスト', () => {
       await test.step('整列ボタンをクリック', async () => {
         const sortButton = adminWindow.locator('button.sort-button');
 
-        // confirmダイアログを受け入れる（重複削除の確認）
-        adminWindow.on('dialog', (dialog) => dialog.accept());
+        // 整列ボタンをクリック
         await sortButton.click();
         await adminUtils.wait(500);
+
+        // 重複削除の確認ダイアログが表示された場合は閉じる
+        const confirmDialog = adminWindow.locator('.confirm-dialog');
+        const isDialogVisible = await confirmDialog.isVisible().catch(() => false);
+        if (isDialogVisible) {
+          // OKボタンをクリックして重複削除を実行
+          const confirmButton = adminWindow.locator('[data-testid="confirm-dialog-confirm-button"]');
+          await confirmButton.click();
+          await adminUtils.wait(300);
+        }
+
         await adminUtils.attachScreenshot(testInfo, '整列後');
 
         // 未保存状態になったことを確認


### PR DESCRIPTION
## 概要

ネイティブダイアログからカスタムReactコンポーネント（ConfirmDialog）への変更に伴い、アイテム管理機能のE2Eテストを修正しました。

## 変更内容

### 修正したテスト（`tests/e2e/specs/item-management.spec.ts`）

1. **アイテムを削除できる**（行265）
   - ネイティブ `adminWindow.on('dialog', ...)` から カスタム `ConfirmDialog` のボタンクリックに変更

2. **チェックボックスで複数アイテムを選択して一括削除できる**（行313）
   - 同様にカスタムConfirmDialog対応

3. **整列ボタンでアイテムを整列できる**（行383）
   - 重複削除ダイアログの条件分岐対応

### 修正コードの例

```typescript
// 修正前（ネイティブダイアログ）
adminWindow.on('dialog', (dialog) => dialog.accept());
await deleteButton.click();

// 修正後（カスタムConfirmDialog）
await deleteButton.click();
const confirmButton = adminWindow.locator('[data-testid="confirm-dialog-confirm-button"]');
await expect(confirmButton).toBeVisible();
await confirmButton.click();
```

## テスト結果

✅ **すべてのE2Eテスト（81件）が成功**

- 総テスト数: 81
- 成功: 81
- 失敗: 0

## 関連コミット

- c40d64a: feat: ネイティブダイアログをカスタムReactコンポーネントに置き換え

🤖 Generated with [Claude Code](https://claude.com/claude-code)