### PR TITLE
fix: グループアイテム選択モーダルでアイテムが表示されない問題を修正

### DIFF
--- a/src/renderer/components/RegisterModal.tsx
+++ b/src/renderer/components/RegisterModal.tsx
@@ -107,6 +107,7 @@ const RegisterModal: React.FC<RegisterModalProps> = ({
             path: '',
             type: 'app',
             targetTab: defaultTab,
+            targetFile: defaultTab,
             itemCategory: 'item',
           },
         ]);
@@ -417,6 +418,7 @@ const RegisterModal: React.FC<RegisterModalProps> = ({
           path: filePath,
           type: itemType,
           targetTab: defaultTab,
+          targetFile: defaultTab,
           folderProcessing: itemType === 'folder' ? 'folder' : undefined,
           icon,
           itemCategory: 'item',

--- a/src/renderer/styles/components/GroupItemSelectorModal.css
+++ b/src/renderer/styles/components/GroupItemSelectorModal.css
@@ -2,7 +2,8 @@
 .group-item-selector-modal {
   max-width: 500px;
   width: 90%;
-  max-height: 600px;
+  height: 600px;
+  max-height: 80vh;
   display: flex;
   flex-direction: column;
   padding: var(--spacing-xl);
@@ -39,13 +40,14 @@
   border: var(--border-light);
   border-radius: var(--border-radius);
   background-color: var(--bg-secondary);
+  min-height: 300px;
   max-height: 400px;
 }
 
 .item-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: var(--spacing-sm);
   padding: var(--spacing-sm) var(--spacing-md);
   cursor: pointer;
   transition: background-color var(--transition-fast);
@@ -64,6 +66,22 @@
   background-color: var(--bg-disabled);
   cursor: not-allowed;
   opacity: 0.6;
+}
+
+.item-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  font-size: var(--font-size-lg);
+}
+
+.item-icon img {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
 }
 
 .item-name {

--- a/tests/dev/with-groups/data.txt
+++ b/tests/dev/with-groups/data.txt
@@ -18,16 +18,16 @@ VS Code,vscode://
 // ========== グループアイテム ==========
 
 // 開発環境を一括起動
-開発環境スタート,GROUP:VS Code,GitHub,Stack Overflow,メモ帳
+group,開発環境スタート,VS Code,GitHub,Stack Overflow,メモ帳
 
 // Web開発用
-Web開発セット,GROUP:VS Code,MDN,GitHub,Google
+group,Web開発セット,VS Code,MDN,GitHub,Google
 
 // ドキュメント作成用
-ドキュメント作成,GROUP:メモ帳,エクスプローラー,電卓
+group,ドキュメント作成,メモ帳,エクスプローラー,電卓
 
 // 調査・学習用
-調査セット,GROUP:Google,Stack Overflow,Qiita,MDN
+group,調査セット,Google,Stack Overflow,Qiita,MDN
 
 // すべてのブラウザを開く
-全ブラウザ,GROUP:GitHub,Google,Stack Overflow,Qiita,MDN
+group,全ブラウザ,GitHub,Google,Stack Overflow,Qiita,MDN


### PR DESCRIPTION
## 概要

グループアイテムの編集時に、アイテム選択モーダルでアイテムが表示されない問題を修正しました。また、メイン画面と同様のアイコン表示を実装し、ユーザビリティを向上させました。

## 修正内容

### 1. データ取得の問題を修正
- **問題**: `RegisterModal`で新規アイテム作成時に`targetFile`が未設定だった
- **修正**: 手動作成時とドロップ時の両方で`targetFile`を設定
  - `RegisterModal.tsx:110` - 手動作成時
  - `RegisterModal.tsx:421` - ドロップ時

### 2. アイコン表示を追加
- **問題**: モーダルでは汎用的な絵文字アイコンのみ表示されていた
- **実装**: メイン画面スタイルのアイコン表示を追加
  - `loadDataFiles()`と`loadCachedIcons()`を使用
  - 実際のファビコンやアプリケーションアイコンを表示
  - アイコンがない場合はタイプ別の絵文字を表示（🌐📁⚙️📄🔗）

### 3. フィルタリング条件を改善
- **追加**: フォルダ取込から展開されたアイテム(`isDirExpanded`)を除外
- **理由**: 展開されたアイテムはデータファイルに存在しないため、グループに追加できない
- **除外対象**:
  - ✅ グループアイテム
  - ✅ フォルダ取込から展開されたアイテム

### 4. UIレイアウトを改善
- モーダルの高さを固定: `height: 600px`, `max-height: 80vh`
- アイテムリストの最小高さを設定: `min-height: 300px`
- アイコン表示用のスタイルを追加
- アイコンと名前の間隔を調整: `gap: var(--spacing-sm)`

### 5. テストデータを更新
- `tests/dev/with-groups/data.txt`のグループアイテム形式を更新
- 古い形式: `開発環境スタート,GROUP:VS Code,GitHub,...`
- 新しい形式: `group,開発環境スタート,VS Code,GitHub,...`

## 変更ファイル

- `src/renderer/components/GroupItemSelectorModal.tsx` - アイコン表示とデータ取得方法を改善
- `src/renderer/components/RegisterModal.tsx` - targetFileの設定を追加
- `src/renderer/styles/components/GroupItemSelectorModal.css` - UIレイアウトとアイコンスタイルを改善
- `tests/dev/with-groups/data.txt` - グループアイテム形式を新形式に更新

## スクリーンショット

修正後、グループアイテム選択モーダルでは以下が表示されるようになりました：
- ✅ データファイルに存在するアイテム一覧
- ✅ メイン画面と同じアイコン（ファビコン、アプリアイコン等）
- ✅ 検索機能
- ✅ 既に追加済みのアイテムは「追加済み」表示で選択不可

## テスト

- [x] 手動テスト: グループアイテム編集画面で「+ アイテムを追加」ボタンをクリック
- [x] アイテム一覧が正しく表示されることを確認
- [x] アイコンがメイン画面と同じものが表示されることを確認
- [x] フォルダ取込から展開されたアイテムが除外されることを確認
- [x] 品質チェック実行: `quality-checker`サブエージェント
  - TypeScript型チェック: ✅ 合格
  - ESLint: ✅ 警告なし（今回修正ファイル）

## 関連Issue

なし（バグ修正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)