### PR TITLE
fix: グループアイテム編集時にアイテム選択ダイアログでデータが表示されない問題を修正

### DIFF
--- a/src/renderer/components/GroupItemSelectorModal.tsx
+++ b/src/renderer/components/GroupItemSelectorModal.tsx
@@ -107,12 +107,16 @@ const GroupItemSelectorModal: React.FC<GroupItemSelectorModalProps> = ({
 
   const loadAvailableItems = async () => {
     try {
-      debugInfo('Loading available items for file:', targetFile);
+      // targetFileが未定義の場合はデフォルトファイルを使用
+      const effectiveTargetFile = targetFile || 'data.txt';
+      debugInfo('Loading available items for file:', effectiveTargetFile);
       const rawLines: RawDataLine[] = await window.electronAPI.loadRawDataFiles();
 
       // 対象ファイルのアイテムのみを抽出
       const itemsInFile = rawLines
-        .filter((line: RawDataLine) => line.sourceFile === targetFile && line.type === 'item')
+        .filter(
+          (line: RawDataLine) => line.sourceFile === effectiveTargetFile && line.type === 'item'
+        )
         .map((line: RawDataLine) => {
           // アイテム名を抽出（カンマ区切りの最初の要素）
           const parts = line.content.split(',');

--- a/src/renderer/components/RegisterModal.tsx
+++ b/src/renderer/components/RegisterModal.tsx
@@ -107,6 +107,7 @@ const RegisterModal: React.FC<RegisterModalProps> = ({
             path: '',
             type: 'app',
             targetTab: defaultTab,
+            targetFile: defaultTab, // グループアイテム選択時に必要
             itemCategory: 'item',
           },
         ]);

--- a/tests/e2e/specs/item-management.spec.ts
+++ b/tests/e2e/specs/item-management.spec.ts
@@ -233,12 +233,12 @@ test.describe('QuickDashLauncher - アイテム管理機能テスト', () => {
       });
 
       await test.step('モーダルで名前と引数を編集', async () => {
-        const nameInput = adminWindow.locator('.register-modal input[placeholder*="表示名"]').first();
+        const nameInput = adminWindow
+          .locator('.register-modal input[placeholder*="表示名"]')
+          .first();
         await nameInput.fill('GitHub詳細編集');
 
-        const argsInput = adminWindow
-          .locator('.register-modal input[placeholder*="引数"]')
-          .first();
+        const argsInput = adminWindow.locator('.register-modal input[placeholder*="引数"]').first();
         await argsInput.fill('--test-args');
         await adminUtils.wait(300);
         await adminUtils.attachScreenshot(testInfo, 'モーダル編集後');
@@ -409,7 +409,9 @@ test.describe('QuickDashLauncher - アイテム管理機能テスト', () => {
         const isDialogVisible = await confirmDialog.isVisible().catch(() => false);
         if (isDialogVisible) {
           // OKボタンをクリックして重複削除を実行
-          const confirmButton = adminWindow.locator('[data-testid="confirm-dialog-confirm-button"]');
+          const confirmButton = adminWindow.locator(
+            '[data-testid="confirm-dialog-confirm-button"]'
+          );
           await confirmButton.click();
           await adminUtils.wait(300);
         }


### PR DESCRIPTION
## Summary
- グループアイテム編集時に「アイテムを追加」ボタンを押したときに、選択可能なアイテムが表示されない問題を修正

## 詳細
- **RegisterModal.tsx**: 新規アイテム作成時に`targetFile`プロパティを`defaultTab`で初期化
- **GroupItemSelectorModal.tsx**: `targetFile`が未定義の場合のフォールバック処理を追加（デフォルト値: 'data.txt'）
- **item-management.spec.ts**: ESLint/Prettierによる自動整形

### 問題の原因
新規アイテム作成時に`targetFile`が設定されていないため、`GroupItemSelectorModal`のフィルタリング条件（`line.sourceFile === targetFile`）が正しく動作せず、アイテムリストが空になっていました。

### 修正内容
1. 新規アイテムテンプレート作成時に`targetFile`を初期化
2. `GroupItemSelectorModal`で`targetFile`が未定義の場合のフォールバック処理を追加

## Test plan
- [x] TypeScript型チェック合格
- [x] ESLint合格
- [x] コード品質チェック合格（quality-checker）
- [ ] 手動テスト: グループアイテム作成→「アイテムを追加」→アイテムリストが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)