### PR TITLE
fix: ブックマークインポート機能のUI表示問題と複数タブ対応を修正

### DIFF
--- a/src/renderer/adminIndex.tsx
+++ b/src/renderer/adminIndex.tsx
@@ -9,6 +9,9 @@ import './styles/components/Modal.css';
 import './styles/components/RegisterModal.css';
 import './styles/components/BookmarkImport.css';
 import './styles/components/IconProgress.css';
+import './styles/components/FilePickerDialog.css';
+import './styles/components/AlertDialog.css';
+import './styles/components/ConfirmDialog.css';
 
 const root = ReactDOM.createRoot(document.getElementById('admin-root') as HTMLElement);
 

--- a/src/renderer/components/BookmarkImportModal.tsx
+++ b/src/renderer/components/BookmarkImportModal.tsx
@@ -3,7 +3,6 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { SimpleBookmarkItem } from '../../common/types';
 
 import AlertDialog from './AlertDialog';
-import FilePickerDialog from './FilePickerDialog';
 
 interface BookmarkImportModalProps {
   isOpen: boolean;
@@ -29,9 +28,6 @@ const BookmarkImportModal: React.FC<BookmarkImportModalProps> = ({ isOpen, onClo
     type: 'info',
   });
 
-  // FilePickerDialog状態管理
-  const [isFilePickerOpen, setIsFilePickerOpen] = useState(false);
-
   // フィルタリングされたブックマーク
   const filteredBookmarks = bookmarks.filter((bookmark) => {
     if (!searchQuery) return true;
@@ -43,13 +39,11 @@ const BookmarkImportModal: React.FC<BookmarkImportModalProps> = ({ isOpen, onClo
   });
 
   // ファイル選択ダイアログを開く
-  const handleSelectFile = () => {
-    setIsFilePickerOpen(true);
-  };
-
-  // ファイルが選択されたときの処理
-  const handleFileSelected = async (filePath: string) => {
+  const handleSelectFile = async () => {
     try {
+      const filePath = await window.electronAPI.selectBookmarkFile();
+      if (!filePath) return; // ユーザーがキャンセルした場合
+
       setLoading(true);
       setFileName(filePath.split(/[\\/]/).pop() || filePath);
       const parsedBookmarks = await window.electronAPI.parseBookmarkFile(filePath);
@@ -170,6 +164,9 @@ const BookmarkImportModal: React.FC<BookmarkImportModalProps> = ({ isOpen, onClo
 
         <div className="bookmark-import-controls">
           <div className="file-select-section">
+            <p className="file-select-description">
+              ブラウザからエクスポートしたブックマークHTMLファイルを選択してください。
+            </p>
             <button onClick={handleSelectFile} className="select-file-button" disabled={loading}>
               {loading ? '読み込み中...' : 'ファイルを選択'}
             </button>
@@ -280,15 +277,6 @@ const BookmarkImportModal: React.FC<BookmarkImportModalProps> = ({ isOpen, onClo
         onClose={() => setAlertDialog({ ...alertDialog, isOpen: false })}
         message={alertDialog.message}
         type={alertDialog.type}
-      />
-
-      <FilePickerDialog
-        isOpen={isFilePickerOpen}
-        onClose={() => setIsFilePickerOpen(false)}
-        onFileSelect={handleFileSelected}
-        title="ブックマークファイルを選択"
-        fileTypes="html"
-        description="ブラウザからエクスポートしたブックマークHTMLファイルを選択してください。"
       />
     </div>
   );

--- a/src/renderer/components/EditModeView.tsx
+++ b/src/renderer/components/EditModeView.tsx
@@ -182,7 +182,7 @@ const EditModeView: React.FC<EditModeViewProps> = ({
       lineNumber: 1,
       content: '',
       type: 'empty',
-      sourceFile: 'data.txt', // デフォルトでdata.txtに追加
+      sourceFile: selectedDataFile, // 現在選択中のファイルに追加
     };
 
     const updatedLines = [newLine, ...workingLines];
@@ -247,7 +247,7 @@ const EditModeView: React.FC<EditModeViewProps> = ({
       lineNumber: index + 1,
       content: `${bookmark.name},${bookmark.url}`,
       type: 'item' as const,
-      sourceFile: 'data.txt' as const,
+      sourceFile: selectedDataFile, // 現在選択中のファイルにインポート
     }));
 
     const updatedLines = [...newLines, ...workingLines];

--- a/src/renderer/components/FilePickerDialog.tsx
+++ b/src/renderer/components/FilePickerDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 
+import '../styles/components/Modal.css';
 import '../styles/components/FilePickerDialog.css';
 
 interface FilePickerDialogProps {

--- a/src/renderer/styles/components/BookmarkImport.css
+++ b/src/renderer/styles/components/BookmarkImport.css
@@ -43,9 +43,17 @@
 
 .file-select-section {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   gap: var(--spacing-sm);
   margin-bottom: var(--spacing-md);
+}
+
+.file-select-description {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
 }
 
 .select-file-button {

--- a/src/renderer/styles/components/FilePickerDialog.css
+++ b/src/renderer/styles/components/FilePickerDialog.css
@@ -2,6 +2,8 @@
 
 .file-picker-dialog {
   max-width: 500px;
+  width: 90%;
+  padding: var(--spacing-xl);
 }
 
 .file-picker-header {
@@ -30,7 +32,7 @@
 
 .browse-button {
   padding: 0.75rem 1.5rem;
-  background-color: var(--primary-color);
+  background-color: var(--color-primary);
   color: white;
   border: none;
   border-radius: var(--border-radius);
@@ -41,9 +43,24 @@
 }
 
 .browse-button:hover {
-  background-color: var(--primary-hover);
+  background-color: var(--color-primary-hover);
 }
 
 .browse-button:active {
   transform: translateY(1px);
+}
+
+.file-picker-dialog .cancel-button {
+  padding: 0.5rem 1.5rem;
+  background-color: var(--color-gray-400);
+  color: white;
+  border: none;
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background-color 0.2s;
+}
+
+.file-picker-dialog .cancel-button:hover {
+  background-color: var(--color-gray-500);
 }


### PR DESCRIPTION
## Summary
管理画面のブックマークインポート機能のUI表示問題を修正し、複数タブ環境での動作を改善しました。

## 変更内容

### UI改善
- **中間ダイアログの削除**: 「ブックマークファイルを選択」ダイアログを削除し、「ファイルを選択」ボタンから直接ネイティブファイル選択ダイアログを開くように変更（クリック数50%削減）
- **説明文の追加**: ファイル選択ボタンの上に説明文を表示
- **CSS変数名の修正**: `--primary-color` → `--color-primary` に統一
- **ダイアログのスタイル修正**: padding追加、キャンセルボタンの色を改善

### バグ修正
- **複数タブ対応**: ブックマークを常に現在選択中のファイルにインポートするよう修正（従来は常に`data.txt`に固定されていた）
- **空行追加の修正**: 空行追加も現在選択中のファイルに追加されるよう修正

## 影響範囲
- `src/renderer/components/BookmarkImportModal.tsx` - FilePickerDialog削除、直接ファイル選択
- `src/renderer/components/EditModeView.tsx` - sourceFileをハードコードから動的に変更
- `src/renderer/components/FilePickerDialog.tsx` - Modal.cssインポート追加
- `src/renderer/styles/components/FilePickerDialog.css` - CSS変数名修正、スタイル追加
- `src/renderer/styles/components/BookmarkImport.css` - 説明文用スタイル追加
- `src/renderer/adminIndex.tsx` - CSS一括インポート追加

## Test plan
- [x] ビルド成功確認（npm run build）
- [x] 型チェック成功確認（npm run type-check）
- [x] ESLint成功確認（npm run lint）
- [ ] 単一タブ環境でブックマークインポート動作確認
- [ ] 複数タブ環境でブックマークインポート動作確認
- [ ] 同一タブ内の複数ファイル環境でブックマークインポート動作確認
- [ ] ファイル選択ダイアログのUI表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)