### PR TITLE
feat(bookmark): Chrome/Edgeブックマーク直接インポート機能を追加

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -83,6 +83,34 @@ export interface SimpleBookmarkItem {
 }
 
 /**
+ * ブラウザのプロファイル情報
+ * Chrome/Edgeの各プロファイルを表す
+ */
+export interface BrowserProfile {
+  /** プロファイルID（フォルダ名: 'Default', 'Profile 1' 等） */
+  id: string;
+  /** プロファイルの表示名（Preferencesから取得） */
+  name: string;
+  /** ブックマークファイルの絶対パス */
+  bookmarkPath: string;
+}
+
+/**
+ * インストール済みブラウザの情報
+ * ブラウザの検出結果とプロファイル一覧を保持
+ */
+export interface BrowserInfo {
+  /** ブラウザの識別子 */
+  id: 'chrome' | 'edge';
+  /** ブラウザの表示名 */
+  name: string;
+  /** インストールされているかどうか */
+  installed: boolean;
+  /** 検出されたプロファイルのリスト */
+  profiles: BrowserProfile[];
+}
+
+/**
  * アプリケーションの設定を管理するインターフェース
  * electron-storeを使用して永続化される
  */

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -10,6 +10,7 @@ import {
   GroupItem,
   AppItem,
   AppInfo,
+  BrowserInfo,
 } from '../common/types';
 
 interface RegisterItem {
@@ -96,6 +97,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getEditMode: () => ipcRenderer.invoke('get-edit-mode'),
   selectBookmarkFile: () => ipcRenderer.invoke('select-bookmark-file'),
   parseBookmarkFile: (filePath: string) => ipcRenderer.invoke('parse-bookmark-file', filePath),
+  // ブラウザブックマーク直接インポートAPI
+  detectInstalledBrowsers: (): Promise<BrowserInfo[]> =>
+    ipcRenderer.invoke('detect-installed-browsers'),
+  parseBrowserBookmarks: (filePath: string) =>
+    ipcRenderer.invoke('parse-browser-bookmarks', filePath),
   // Settings API
   getSettings: (key?: keyof AppSettings) => ipcRenderer.invoke('settings:get', key),
   setSetting: (key: keyof AppSettings, value: AppSettings[keyof AppSettings]) =>

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -9,6 +9,7 @@ import {
   GroupItem,
   AppItem,
   AppInfo,
+  BrowserInfo,
 } from '../common/types';
 
 import { RegisterItem } from './components/RegisterModal';
@@ -85,6 +86,9 @@ export interface ElectronAPI {
   getEditMode: () => Promise<boolean>;
   selectBookmarkFile: () => Promise<string | null>;
   parseBookmarkFile: (filePath: string) => Promise<SimpleBookmarkItem[]>;
+  // ブラウザブックマーク直接インポートAPI
+  detectInstalledBrowsers: () => Promise<BrowserInfo[]>;
+  parseBrowserBookmarks: (filePath: string) => Promise<SimpleBookmarkItem[]>;
   showEditWindow: () => Promise<void>;
   hideEditWindow: () => Promise<void>;
   toggleEditWindow: () => Promise<void>;

--- a/src/renderer/styles/components/BookmarkImport.css
+++ b/src/renderer/styles/components/BookmarkImport.css
@@ -41,6 +41,126 @@
   border-bottom: var(--border-light);
 }
 
+/* インポート元選択セクション */
+.import-source-section {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-sm);
+}
+
+.import-source-label {
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  font-size: var(--font-size-base);
+  white-space: nowrap;
+}
+
+.import-source-buttons {
+  display: flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.import-source-button {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border: 2px solid var(--color-gray-300);
+  border-radius: var(--border-radius);
+  background-color: var(--color-white);
+  cursor: pointer;
+  transition: var(--transition-normal);
+  font-size: var(--font-size-base);
+  font-family: inherit;
+}
+
+.import-source-button:hover:not(:disabled) {
+  border-color: var(--color-info);
+  background-color: var(--bg-hover);
+}
+
+.import-source-button.selected {
+  border-color: var(--color-info);
+  background-color: var(--color-info-light);
+}
+
+.import-source-button.disabled,
+.import-source-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.import-source-icon {
+  font-size: var(--font-size-lg);
+}
+
+.loading-text {
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
+/* プロファイル選択セクション */
+.profile-select-section {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-md);
+}
+
+.profile-select-label {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: var(--font-size-base);
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.profile-selector {
+  flex: 1;
+  max-width: 250px;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border: var(--border-normal);
+  border-radius: var(--border-radius);
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  background-color: var(--color-white);
+}
+
+.profile-selector:focus {
+  outline: none;
+  border-color: var(--color-info);
+  box-shadow: 0 0 0 2px var(--color-info-light);
+}
+
+.load-bookmarks-button {
+  align-self: flex-start;
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background-color: var(--color-info);
+  color: var(--color-white);
+  border: none;
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  transition: var(--transition-normal);
+}
+
+.load-bookmarks-button:hover:not(:disabled) {
+  background-color: var(--color-info-hover);
+}
+
+.load-bookmarks-button:disabled {
+  background-color: var(--color-gray-400);
+  cursor: not-allowed;
+}
+
 .file-select-section {
   display: flex;
   flex-direction: column;
@@ -52,7 +172,7 @@
 .file-select-description {
   margin: 0;
   color: var(--text-secondary);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-base);
   line-height: 1.5;
 }
 


### PR DESCRIPTION
## Summary
- Chrome/Edgeブラウザのブックマークを直接読み取ってインポートする機能を追加
- ブラウザからHTMLファイルをエクスポートする手順が不要に
- 複数プロファイルに対応（プルダウンで選択可能）
- 既存のHTMLインポート機能と併存（3択UI: Chrome / Edge / HTMLファイル）

## 変更内容
- `BrowserInfo`, `BrowserProfile` 型を追加
- `detectInstalledBrowsers` API: インストール済みブラウザとプロファイルを検出
- `parseBrowserBookmarks` API: ブラウザのJSONブックマークファイルを解析
- インポート元選択UIとプロファイル選択ドロップダウンを追加
- セキュリティ対策: LOCALAPPDATA配下のみアクセス許可、パストラバーサル防止

## Test plan
- [ ] Chromeがインストールされている環境でブックマークインポートを確認
- [ ] Edgeがインストールされている環境でブックマークインポートを確認
- [ ] 複数プロファイルがある場合のプロファイル切り替えを確認
- [ ] HTMLファイルインポートが引き続き動作することを確認
- [ ] 未インストールブラウザのボタンが無効化されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)