### PR TITLE
feat: 設定ファイルにバージョン情報を記録する機能を追加

### DIFF
--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -44,6 +44,8 @@ QuickDashLauncherの動作をカスタマイズするための設定機能を説
 
 | キー | 型 | デフォルト | 説明 |
 |------|-----|-----------|------|
+| `createdWithVersion` | `string?` | `undefined` | 設定ファイルを作成したアプリバージョン（新規作成時のみ自動記録） |
+| `updatedWithVersion` | `string?` | `undefined` | 設定ファイルを最後に更新したアプリバージョン（更新時に自動記録） |
 | `hotkey` | `string` | `''` | グローバルホットキー |
 | `windowWidth` | `number` | `600` | 通常時のウィンドウ幅 |
 | `windowHeight` | `number` | `400` | 通常時のウィンドウ高さ |
@@ -221,6 +223,8 @@ $env:QUICK_DASH_CONFIG_DIR = "D:\MyApps\quick-dash-config"
 
 ```json
 {
+  "createdWithVersion": "0.4.3",
+  "updatedWithVersion": "0.4.3",
   "hotkey": "Alt+Space",
   "windowWidth": 600,
   "windowHeight": 400,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -87,6 +87,10 @@ export interface SimpleBookmarkItem {
  * electron-storeを使用して永続化される
  */
 export interface AppSettings {
+  /** この設定ファイルを作成したアプリバージョン（初回作成時のみ記録） */
+  createdWithVersion?: string;
+  /** この設定ファイルを最後に更新したアプリバージョン */
+  updatedWithVersion?: string;
   /** グローバルホットキー（デフォルト: 'Alt+Space'） */
   hotkey: string;
   /** ウィンドウの初期幅（デフォルト: 600） */

--- a/src/main/services/settingsService.ts
+++ b/src/main/services/settingsService.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import ElectronStore from 'electron-store';
 
 import type { AppSettings } from '../../common/types.js';
@@ -74,11 +77,20 @@ export class SettingsService {
       // PathManagerから設定フォルダを取得
       const configFolder = PathManager.getConfigFolder();
 
+      // 設定ファイルが既に存在するかチェック（新規作成判定用）
+      const settingsFilePath = path.join(configFolder, 'settings.json');
+      const isNewFile = !fs.existsSync(settingsFilePath);
+
       this.store = new Store!<AppSettings>({
         name: 'settings',
         cwd: configFolder, // カスタムパスを指定
         defaults: SettingsService.DEFAULT_SETTINGS,
       }) as unknown as StoreInstance;
+
+      // 新規作成時のみバージョンを記録
+      if (isNewFile) {
+        await this.setCreatedWithVersion();
+      }
 
       logger.info(`SettingsService initialized successfully at ${configFolder}`);
     } catch (error) {
@@ -124,6 +136,7 @@ export class SettingsService {
     if (!this.store) throw new Error('Store not initialized');
     try {
       this.store.set(key, value);
+      await this.updateVersionIfNeeded(key);
       logger.info(`Setting ${key} updated to:`, value);
     } catch (error) {
       logger.error(`Failed to set setting ${key}:`, error);
@@ -139,11 +152,27 @@ export class SettingsService {
     await this.initializeStore();
     if (!this.store) throw new Error('Store not initialized');
     try {
+      // バージョン情報以外のキーがあるかチェック
+      const hasNonVersionKey = Object.keys(settings).some(
+        (key) => key !== 'createdWithVersion' && key !== 'updatedWithVersion'
+      );
+
       Object.entries(settings).forEach(([key, value]) => {
         if (value !== undefined && this.store) {
           this.store.set(key as keyof AppSettings, value);
         }
       });
+
+      // バージョン情報以外の更新があった場合のみ更新バージョンを記録
+      if (hasNonVersionKey) {
+        const version = await this.getAppVersion();
+        const currentVersion = this.store.get('updatedWithVersion');
+        if (currentVersion !== version) {
+          this.store.set('updatedWithVersion', version);
+          logger.info(`Settings file updated with version: ${version}`);
+        }
+      }
+
       logger.info('Multiple settings updated:', settings);
     } catch (error) {
       logger.error('Failed to set multiple settings:', error);
@@ -206,6 +235,58 @@ export class SettingsService {
     }
 
     return { isValid: true };
+  }
+
+  /**
+   * 現在のアプリバージョンを取得
+   */
+  private async getAppVersion(): Promise<string> {
+    try {
+      const packageJson = await import('../../../package.json');
+      return packageJson.version || '0.0.0';
+    } catch (error) {
+      logger.error('Failed to get app version:', error);
+      return '0.0.0';
+    }
+  }
+
+  /**
+   * 設定ファイルに作成時のアプリバージョンを記録
+   * 新規作成時のみ呼び出される
+   */
+  private async setCreatedWithVersion(): Promise<void> {
+    if (!this.store) return;
+
+    try {
+      const version = await this.getAppVersion();
+      this.store.set('createdWithVersion', version);
+      this.store.set('updatedWithVersion', version);
+      logger.info(`Settings file created with version: ${version}`);
+    } catch (error) {
+      logger.error('Failed to set createdWithVersion:', error);
+    }
+  }
+
+  /**
+   * 設定ファイルの更新バージョンを記録
+   */
+  private async updateVersionIfNeeded(key: keyof AppSettings): Promise<void> {
+    // バージョン情報フィールド自体の更新時は記録しない（無限ループ防止）
+    if (key === 'createdWithVersion' || key === 'updatedWithVersion') {
+      return;
+    }
+    if (!this.store) return;
+
+    try {
+      const version = await this.getAppVersion();
+      const currentVersion = this.store.get('updatedWithVersion');
+      if (currentVersion !== version) {
+        this.store.set('updatedWithVersion', version);
+        logger.info(`Settings file updated with version: ${version}`);
+      }
+    } catch (error) {
+      logger.error('Failed to update updatedWithVersion:', error);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- 設定ファイル（settings.json）にバージョン情報フィールドを追加
  - `createdWithVersion`: 設定ファイル作成時のアプリバージョン（初回のみ記録）
  - `updatedWithVersion`: 設定ファイル更新時のアプリバージョン（更新のたびに記録）
- 設定ファイルがどのバージョンで作成・更新されたかを追跡可能に

## 変更内容
- `src/common/types.ts`: AppSettingsインターフェースに2フィールド追加
- `src/main/services/settingsService.ts`: バージョン記録ロジック追加
- `docs/features/settings.md`: 設定仕様書を更新

## Test plan
- [ ] 新規設定ファイル作成時に両フィールドが記録されることを確認
- [ ] 設定変更時にupdatedWithVersionが更新されることを確認
- [ ] 既存の設定ファイルではバージョン情報が追加されないことを確認
- [ ] 型チェック・単体テストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)