### PR TITLE
refactor(ui): CSS命名規則の整理とデータファイル開く機能の削除

### DIFF
--- a/docs/architecture/css-design.md
+++ b/docs/architecture/css-design.md
@@ -434,9 +434,8 @@ const MyComponent = () => {
   - ❌ 誤: `.btn-danger-small`, `.btn-primary-large`
 
 **アクションボタン**:
-- 統一形: `.action-btn` （32x32ピクセルの正方形ボタン）
-  - ✅ 正: `.action-btn`
-  - ❌ 誤: `.action-button`
+- `.action-btn` : 32x32ピクセルの正方形アイコンボタン（メインウィンドウヘッダー用）
+- `.section-action-button` : 横長テキスト付きボタン（管理ウィンドウのセクション内用）
 
 **コンポーネント要素**:
 - パターン: `.{component}-{element}` （例: `.modal-overlay`, `.item-icon`）
@@ -523,10 +522,10 @@ const MyComponent = () => {
 
 **修正内容**:
 
-1. **アクションボタンの統一**
-   - 変更前: `Header.css`で `.action-button` を使用
-   - 変更後: `.action-btn` に統一（`common.css`の命名規則に合わせる）
-   - 影響範囲: 4つのコンポーネント（ActionButtons, SettingsDropdown, RefreshActionsDropdown, AdminOtherTab）
+1. **アクションボタンの命名整理**
+   - `.action-btn` : 32x32正方形アイコンボタン（メインウィンドウヘッダー用、`common.css`で定義）
+   - `.section-action-button` : 横長テキストボタン（管理ウィンドウ用、`AdminWindow.css`で定義）
+   - 紛らわしかった `.action-button` は削除済み
 
 2. **サイズバリエーションの統一**
    - 変更前: `AdminWindow.css`で `.btn-secondary-small`, `.btn-danger-small` を使用

--- a/src/main/ipc/configHandlers.ts
+++ b/src/main/ipc/configHandlers.ts
@@ -8,11 +8,6 @@ export function setupConfigHandlers(configFolder: string) {
     await shell.openPath(configFolder);
   });
 
-  ipcMain.handle('open-data-file', async () => {
-    const dataPath = path.join(configFolder, 'data.txt');
-    await shell.openPath(dataPath);
-  });
-
   ipcMain.handle('get-app-info', async () => {
     try {
       // package.jsonのパスを取得（productionとdevelopmentで異なる）

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -41,7 +41,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   executeGroup: (group: GroupItem, allItems: AppItem[]) =>
     ipcRenderer.invoke('execute-group', group, allItems),
   openConfigFolder: () => ipcRenderer.invoke('open-config-folder'),
-  openDataFile: () => ipcRenderer.invoke('open-data-file'),
   fetchFavicon: (url: string) => ipcRenderer.invoke('fetch-favicon', url),
   extractIcon: (filePath: string) => ipcRenderer.invoke('extract-icon', filePath),
   extractFileIconByExtension: (filePath: string) =>

--- a/src/renderer/components/AdminOtherTab.tsx
+++ b/src/renderer/components/AdminOtherTab.tsx
@@ -16,10 +16,6 @@ const AdminOtherTab: React.FC = () => {
     window.electronAPI.openConfigFolder();
   };
 
-  const handleOpenDataFile = () => {
-    window.electronAPI.openDataFile();
-  };
-
   const handleQuitApp = () => {
     if (confirm('アプリケーションを終了しますか？')) {
       window.electronAPI.quitApp();
@@ -38,11 +34,8 @@ const AdminOtherTab: React.FC = () => {
         <div className="section">
           <h3>ファイル管理</h3>
           <div className="action-buttons">
-            <button onClick={handleOpenConfigFolder} className="action-btn">
+            <button onClick={handleOpenConfigFolder} className="section-action-button">
               📁 設定フォルダを開く
-            </button>
-            <button onClick={handleOpenDataFile} className="action-btn">
-              📄 データファイルを開く
             </button>
           </div>
         </div>

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -23,7 +23,6 @@ export interface ElectronAPI {
   openParentFolder: (item: LauncherItem) => Promise<void>;
   executeGroup: (group: GroupItem, allItems: AppItem[]) => Promise<void>;
   openConfigFolder: () => Promise<void>;
-  openDataFile: () => Promise<void>;
   fetchFavicon: (url: string) => Promise<string | null>;
   extractIcon: (filePath: string) => Promise<string | null>;
   extractFileIconByExtension: (filePath: string) => Promise<string | null>;

--- a/src/renderer/styles/components/AdminWindow.css
+++ b/src/renderer/styles/components/AdminWindow.css
@@ -294,7 +294,7 @@
   gap: var(--spacing-sm);
 }
 
-.action-button {
+.section-action-button {
   padding: var(--spacing-sm) var(--spacing-lg);
   border: var(--border-normal);
   border-radius: var(--border-radius);
@@ -309,7 +309,7 @@
   gap: var(--spacing-sm);
 }
 
-.action-button:hover {
+.section-action-button:hover {
   background-color: var(--bg-hover);
   border-color: var(--color-primary);
 }

--- a/tests/e2e/helpers/test-utils.ts
+++ b/tests/e2e/helpers/test-utils.ts
@@ -114,7 +114,7 @@ export class TestUtils {
    * 登録モーダルを開く（プラスボタンをクリック）
    */
   async openRegisterModal(): Promise<void> {
-    const registerButton = this.page.locator('.action-button.register-item');
+    const registerButton = this.page.locator('.action-btn[title="アイテムを登録"]');
     await registerButton.click();
     await this.page.waitForSelector('.register-modal', { state: 'visible' });
   }


### PR DESCRIPTION
## 概要
管理画面のその他タブから「データファイルを開く」機能を削除し、CSS命名規則の不整合を解消しました。

## 変更内容

### 1. 「データファイルを開く」ボタンの削除
- タブ機能により複数のデータファイルが存在するようになったため、単一のデータファイルを開く機能は不要
- `AdminOtherTab.tsx`から該当ボタンと`handleOpenDataFile`関数を削除
- 関連するAPI定義とIPCハンドラも削除

### 2. CSS命名規則の整理
- 紛らわしい`.action-button`を`.section-action-button`に変更
- `.action-btn`（32x32正方形アイコンボタン）と`.section-action-button`（横長テキストボタン）を明確に区別
- ドキュメント（css-design.md）を更新し、命名規則を明記

### 3. テストの修正
- 不正なセレクタ`.action-button.register-item`を`.action-btn[title="アイテムを登録"]`に修正

### 4. 表示崩れの修正
- 「設定フォルダを開く」ボタンが縦書きになっていた問題を修正
- 正しいCSSクラスを適用することで解決

## 削除されたAPI
- `ElectronAPI.openDataFile()`
- IPC channel: `open-data-file`

## 影響範囲
- 管理ウィンドウのその他タブ
- E2Eテスト

## テスト
- ✅ TypeScript型チェック: エラーなし
- ✅ ESLint: エラーなし
- ✅ 単体テスト: 全27テスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)