### PR TITLE
fix(settings): タブ名変更時の保存処理を追加

### DIFF
--- a/src/renderer/components/SettingsTab.tsx
+++ b/src/renderer/components/SettingsTab.tsx
@@ -873,6 +873,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({ settings, onSave }) => {
                               type="text"
                               value={tab.name}
                               onChange={(e) => handleTabNameChangeByIndex(tabIndex, e.target.value)}
+                              onBlur={handleTabNameBlur}
                               className="tab-name-input"
                               placeholder={`タブ ${tabIndex + 1}`}
                               disabled={isLoading}


### PR DESCRIPTION
## 概要
設定画面のタブ名入力フィールドにonBlurハンドラを追加し、タブ名変更時の保存処理を実装しました。

## 変更内容
- `src/renderer/components/SettingsTab.tsx`: タブ名入力フィールドに`onBlur={handleTabNameBlur}`を追加

## 問題点
タブ名を変更しても保存されない問題がありました。タブ名入力フィールドには`onChange`ハンドラのみが設定されており、ローカル状態の更新のみが行われていました。他の操作（タブ移動など）を行わない限り、変更が保存されませんでした。

## 解決方法
既存の`handleTabNameBlur`関数を活用し、タブ名入力フィールドにonBlurハンドラを追加。これにより、フォーカスを失ったタイミングで自動保存されるようになりました。

## テスト方法
1. 設定画面を開く
2. 「複数タブを表示」を有効化
3. タブ名を変更
4. 別の場所をクリックしてフォーカスを外す
5. 設定画面を閉じて再度開く
6. タブ名が保存されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)