### PR TITLE
feat: RegisterModalに削除機能を追加

### DIFF
--- a/src/renderer/components/RegisterModal.tsx
+++ b/src/renderer/components/RegisterModal.tsx
@@ -16,6 +16,7 @@ interface RegisterModalProps {
   droppedPaths: string[];
   editingItem?: RawDataLine | null;
   currentTab?: string; // 現在開いているタブ
+  onDelete?: (item: RawDataLine) => void; // 削除ハンドラー
 }
 
 const RegisterModal: React.FC<RegisterModalProps> = ({
@@ -25,6 +26,7 @@ const RegisterModal: React.FC<RegisterModalProps> = ({
   droppedPaths,
   editingItem,
   currentTab,
+  onDelete,
 }) => {
   const modalRef = useRef<HTMLDivElement>(null);
 
@@ -208,6 +210,13 @@ const RegisterModal: React.FC<RegisterModalProps> = ({
       await deleteCustomIcon(index, item.customIcon, (idx) => {
         updateItem(idx, { customIcon: undefined });
       });
+    }
+  };
+
+  // アイテム削除ハンドラー
+  const handleDelete = () => {
+    if (editingItem && onDelete) {
+      onDelete(editingItem);
     }
   };
 
@@ -438,10 +447,17 @@ const RegisterModal: React.FC<RegisterModalProps> = ({
               </div>
 
               <div className="modal-actions">
-                <button onClick={handleCancel}>キャンセル</button>
-                <button onClick={validateAndRegister} className="primary">
-                  {editingItem ? '更新' : '登録'}
-                </button>
+                {editingItem && onDelete && (
+                  <button onClick={handleDelete} className="danger">
+                    削除
+                  </button>
+                )}
+                <div className="modal-actions-right">
+                  <button onClick={handleCancel}>キャンセル</button>
+                  <button onClick={validateAndRegister} className="primary">
+                    {editingItem ? '更新' : '登録'}
+                  </button>
+                </div>
               </div>
             </>
           )}

--- a/src/renderer/styles/components/RegisterModal.css
+++ b/src/renderer/styles/components/RegisterModal.css
@@ -233,3 +233,31 @@
   margin-top: var(--spacing-xs);
   font-weight: 500;
 }
+
+/* モーダルアクションボタンのレイアウト調整 */
+.modal-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding-top: var(--spacing-lg);
+  border-top: var(--border-light);
+}
+
+.modal-actions-right {
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-left: auto;
+}
+
+/* 削除ボタン（dangerスタイル） */
+.modal-actions button.danger {
+  background-color: var(--color-danger);
+  color: var(--color-white);
+  border-color: var(--color-danger);
+}
+
+.modal-actions button.danger:hover {
+  background-color: var(--color-danger-hover);
+  border-color: var(--color-danger-hover);
+}


### PR DESCRIPTION
## Summary
RegisterModal（アイテム編集ポップアップ）に削除機能を追加しました。編集画面から直接アイテムを削除できるようになります。

## Changes
- RegisterModalに削除ボタンを追加（編集モード時のみ表示）
- 削除前に確認ダイアログを表示（danger=true）
- 削除後は自動的にモーダルを閉じてデータを再読み込み

## Modified Files
- `src/renderer/styles/components/RegisterModal.css` - 削除ボタンのスタイル追加
- `src/renderer/components/RegisterModal.tsx` - 削除ボタンUI実装
- `src/renderer/App.tsx` - 削除ハンドラーと確認ダイアログ実装

## UI
### ボタン配置
- 左側: 削除ボタン（赤色・dangerスタイル）
- 右側: キャンセル、更新/登録ボタン

### 動作フロー
1. メイン画面でアイテムを右クリック→「編集」
2. RegisterModalが開く→左側に赤い「削除」ボタンが表示される
3. 削除ボタンをクリック→確認ダイアログが表示される
4. OKをクリック→アイテムが削除され、モーダルが閉じる

## Test plan
- [x] TypeScript型チェック通過
- [x] ビルド成功
- [x] 単体テスト100%通過
- [ ] 編集モード時に削除ボタンが表示されることを確認
- [ ] 新規登録モード時に削除ボタンが非表示であることを確認
- [ ] 削除ボタンクリックで確認ダイアログが表示されることを確認
- [ ] OKで削除、キャンセルで中止されることを確認
- [ ] 削除後にアイテムリストが更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)