### PR TITLE
feat(ui): ヘッダーにドラッグハンドルを追加

### DIFF
--- a/src/main/ipc/dataHandlers.ts
+++ b/src/main/ipc/dataHandlers.ts
@@ -849,7 +849,10 @@ async function parseBrowserBookmarks(filePath: string): Promise<SimpleBookmarkIt
       }
     }
 
-    dataLogger.info({ filePath, bookmarkCount: bookmarks.length }, 'ブラウザブックマークをパースしました');
+    dataLogger.info(
+      { filePath, bookmarkCount: bookmarks.length },
+      'ブラウザブックマークをパースしました'
+    );
 
     return bookmarks;
   } catch (error) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -436,6 +436,7 @@ const App: React.FC = () => {
             windowPinMode={windowPinMode}
             isEditMode={false}
           />
+          <div className="drag-handle">⋮⋮</div>
         </div>
 
         {showDataFileTabs && dataFileTabs.length > 1 && (

--- a/src/renderer/components/AdminTabContainer.tsx
+++ b/src/renderer/components/AdminTabContainer.tsx
@@ -60,6 +60,7 @@ const AdminTabContainer: React.FC<AdminTabContainerProps> = ({
             📊 その他
           </button>
         </div>
+        <div className="drag-handle">⋮⋮</div>
       </div>
 
       <div className="admin-content">

--- a/src/renderer/styles/components/AdminWindow.css
+++ b/src/renderer/styles/components/AdminWindow.css
@@ -23,6 +23,23 @@
   -webkit-app-region: drag;
 }
 
+/* ドラッグハンドル */
+.admin-header .drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  height: 40px;
+  padding: 0;
+  color: var(--color-gray-800);
+  font-size: var(--font-size-xl);
+  font-weight: bold;
+  cursor: move;
+  user-select: none;
+  margin-left: calc(var(--spacing-sm) * -0.5);
+  margin-right: calc(var(--spacing-lg) * -0.5);
+}
+
 .admin-tabs {
   display: flex;
   gap: 2px;

--- a/src/renderer/styles/components/Header.css
+++ b/src/renderer/styles/components/Header.css
@@ -9,6 +9,23 @@
   -webkit-app-region: drag;
 }
 
+/* ドラッグハンドル */
+.drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  height: 40px;
+  padding: 0;
+  color: var(--color-gray-800);
+  font-size: var(--font-size-xl);
+  font-weight: bold;
+  cursor: move;
+  user-select: none;
+  margin-left: calc(var(--spacing-sm) * -0.5);
+  margin-right: calc(var(--spacing-sm) * -0.5);
+}
+
 .search-box-container {
   flex: 1;
   position: relative;


### PR DESCRIPTION
## Summary

メインウィンドウと管理画面のヘッダーに視覚的なドラッグハンドル（⋮⋮）を追加しました。
設定アイコンの右側に配置し、ウィンドウのドラッグ操作がより直感的になりました。

### 変更内容

- **メインウィンドウ**: ヘッダー右端にドラッグハンドルを追加
- **管理画面**: タブバー右端にドラッグハンドルを追加
- **スタイル**: CSS変数を使用した定義（CSSデザインシステムに準拠）
- **視認性**: 太字で濃いグレー表示により、ドラッグ可能な領域が一目でわかる

### UI改善点

- ウィンドウをドラッグできる領域が視覚的に明確になった
- 設定アイコンとドラッグハンドルの間隔を最適化
- 右側の余白を削減してコンパクトに配置

## Test plan

- [x] メインウィンドウのドラッグハンドルでウィンドウをドラッグできることを確認
- [x] 管理画面のドラッグハンドルでウィンドウをドラッグできることを確認
- [x] ドラッグハンドルの表示位置とスタイルが適切であることを確認
- [x] TypeScript型チェックとESLintが通ることを確認
- [x] CSSデザインシステムに準拠していることを確認（CSS変数使用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)