### PR TITLE
選択中アイテムの文字色を白色に修正して視認性を向上

### DIFF
--- a/src/main/adminWindowManager.ts
+++ b/src/main/adminWindowManager.ts
@@ -40,6 +40,7 @@ export async function createAdminWindow(): Promise<BrowserWindow> {
     autoHideMenuBar: true, // メニューバーを自動的に非表示にする
     show: false,
     title: 'QuickDashLauncher - 設定・管理',
+    icon: path.join(__dirname, '../../assets/icon.ico'),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,

--- a/src/main/splashWindowManager.ts
+++ b/src/main/splashWindowManager.ts
@@ -22,6 +22,7 @@ export async function createSplashWindow(): Promise<BrowserWindow> {
     maximizable: false,
     minimizable: false,
     show: true,
+    icon: path.join(__dirname, '../../assets/icon.ico'),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,

--- a/src/renderer/styles/components/ItemList.css
+++ b/src/renderer/styles/components/ItemList.css
@@ -26,6 +26,10 @@
   color: var(--color-white);
 }
 
+.item.selected .item-name {
+  color: var(--color-white);
+}
+
 .item-icon {
   width: var(--icon-size-sm);
   height: var(--icon-size-sm);


### PR DESCRIPTION
## Summary
- メインウィンドウで選択中のアイテムの文字色が黒のままで見づらかった問題を修正
- `.item.selected .item-name`に明示的に白色を指定して視認性を向上
- 管理画面とスプラッシュ画面にウィンドウアイコンを追加

## 変更内容
### UI改善
- `src/renderer/styles/components/ItemList.css`: 選択中アイテムの`.item-name`に白色を明示的に指定
  - 背景色: 濃い青 (`#0078d4`)
  - 文字色: 白 (`#ffffff`)
  - 高コントラストで視認性向上

### ウィンドウアイコン追加
- `src/main/adminWindowManager.ts`: 管理画面にアイコンを追加
- `src/main/splashWindowManager.ts`: スプラッシュ画面にアイコンを追加

## Test plan
- [x] 開発モードでメインウィンドウを起動し、選択中アイテムの文字が白色になることを確認
- [x] 管理画面とスプラッシュ画面でアイコンが表示されることを確認
- [x] TypeScript型チェック合格
- [x] ESLintチェック合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)