### PR TITLE
feat(edit-mode): 管理画面のアイテム一覧にアイコン列を追加

### DIFF
--- a/src/renderer/styles/components/EditMode.css
+++ b/src/renderer/styles/components/EditMode.css
@@ -633,6 +633,26 @@
   padding: var(--spacing-xs) 6px !important;
 }
 
+.icon-column {
+  width: 32px;
+  text-align: center;
+  padding: var(--spacing-xs) 4px !important;
+}
+
+.icon-column .item-icon-image {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+  vertical-align: middle;
+}
+
+.icon-column .folder-emoji {
+  font-size: 20px;
+  line-height: 24px;
+  display: inline-block;
+  vertical-align: middle;
+}
+
 .type-icon {
   margin-right: 4px;
   font-size: 14px;


### PR DESCRIPTION
## Summary
- 管理画面のアイテム管理テーブルにアイコン列を追加し、Main Windowと同じアイコン表示を実現

## 詳細

### 変更内容
- **アイコン列の追加**: 種類列と名前列の間に専用のアイコン列を追加
- **アイコン表示機能の実装**:
  - `loadCachedIcons()` APIを使用してMain Windowと同じアイコンを表示
  - URLアイテム → ファビコン表示
  - EXE/アプリ → 自動取得アイコン表示
  - カスタムアイコン設定済み → カスタムアイコン表示
  - フォルダ → 📁絵文字表示
- **型判定の改善**: `detectItemTypeSync()`を使用してパスから正しいアイテムタイプを判定
- **Main Windowとの統合**: アイコンキャッシュを共有し、一貫した表示を実現

### 修正ファイル
- `src/renderer/components/EditableRawItemList.tsx`
  - useEffectでアイコン一括取得処理を追加
  - renderIconCell()関数を実装
  - アイコン列をテーブルに追加
- `src/renderer/styles/components/EditMode.css`
  - アイコン列のスタイル定義
  - フォルダ絵文字のスタイル定義

## Test plan
- [x] URLアイテムでファビコンが表示される
- [x] EXE/アプリで自動取得アイコンが表示される
- [x] フォルダで📁絵文字が表示される
- [x] Main Windowと同じアイコンが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)