### PR TITLE
ボタン色の統一化とCSS変数の整理

### DIFF
--- a/src/renderer/styles/common.css
+++ b/src/renderer/styles/common.css
@@ -85,6 +85,17 @@
   border-color: var(--color-gray-600);
 }
 
+.btn-info {
+  background-color: var(--color-info);
+  color: var(--color-white);
+  border-color: var(--color-info);
+}
+
+.btn-info:hover:not(:disabled) {
+  background-color: var(--color-info-hover);
+  border-color: var(--color-info-hover);
+}
+
 .btn-sm {
   padding: var(--spacing-xs) var(--spacing-md);
   font-size: var(--font-size-sm);

--- a/src/renderer/styles/components/AdminWindow.css
+++ b/src/renderer/styles/components/AdminWindow.css
@@ -243,12 +243,12 @@
 }
 
 .reset-button {
-  background-color: var(--color-danger-light);
+  background-color: var(--color-danger);
   color: var(--color-white);
 }
 
 .reset-button:hover:not(:disabled) {
-  background-color: var(--color-danger-light-hover);
+  background-color: var(--color-danger-hover);
 }
 
 .revert-button {
@@ -262,12 +262,12 @@
 }
 
 .save-button {
-  background-color: var(--color-success-light);
+  background-color: var(--color-success);
   color: var(--color-white);
 }
 
 .save-button:hover:not(:disabled) {
-  background-color: var(--color-success-light-hover);
+  background-color: var(--color-success-hover);
 }
 
 .reset-button:disabled,

--- a/src/renderer/styles/components/EditMode.css
+++ b/src/renderer/styles/components/EditMode.css
@@ -809,3 +809,13 @@
   color: var(--color-white);
   border-color: var(--color-secondary);
 }
+
+.type-select-button.group-button {
+  border-color: var(--color-info);
+}
+
+.type-select-button.group-button:hover {
+  background-color: var(--color-info);
+  color: var(--color-white);
+  border-color: var(--color-info);
+}

--- a/src/renderer/styles/components/Header.css
+++ b/src/renderer/styles/components/Header.css
@@ -138,8 +138,8 @@
 }
 
 .action-btn.pin-always-on-top:hover {
-  background-color: var(--color-danger-light) !important;
-  border-color: var(--color-danger-light);
+  background-color: var(--color-danger-alt) !important;
+  border-color: var(--color-danger-alt);
   box-shadow: var(--shadow);
   transform: scale(1.05);
 }

--- a/src/renderer/styles/components/HotkeyInput.css
+++ b/src/renderer/styles/components/HotkeyInput.css
@@ -26,7 +26,7 @@
 }
 
 .hotkey-input.recording {
-  border-color: var(--color-danger-light);
+  border-color: var(--color-danger);
   background-color: var(--bg-danger-light);
   box-shadow: var(--focus-ring-danger);
   animation: pulse 1s infinite;
@@ -49,7 +49,7 @@
   right: 0;
   margin-top: var(--spacing-xs);
   padding: var(--spacing-xs) var(--spacing-sm);
-  background-color: var(--color-danger-light);
+  background-color: var(--color-danger);
   color: var(--color-white);
   border-radius: var(--border-radius);
   font-size: var(--font-size-xs);

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -7,13 +7,9 @@
 
   --color-success: #28a745;
   --color-success-hover: #218838;
-  --color-success-light: #4caf50;
-  --color-success-light-hover: #45a049;
 
   --color-danger: #dc3545;
   --color-danger-hover: #c82333;
-  --color-danger-light: #ff6b6b;
-  --color-danger-light-hover: #ff5252;
   --color-danger-alt: #ff4757;
   --color-danger-alt-hover: #ff5252;
 


### PR DESCRIPTION
## Summary
- アプリケーション全体でボタンの色使いを統一
- 不要なCSS変数を削除してメンテナンス性を向上
- グループ選択ボタンのスタイルを追加

## 変更内容

### CSS変数の整理 (variables.css)
- `--color-success-light` (#4caf50) を削除
- `--color-success-light-hover` (#45a049) を削除
- `--color-danger-light` (#ff6b6b) を削除
- `--color-danger-light-hover` (#ff5252) を削除

### ボタン色の統一
| 用途 | 統一後の色 | 色コード |
|-----|-----------|---------|
| 保存・追加・確認 | `--color-success` | #28a745 |
| 削除・リセット | `--color-danger` | #dc3545 |
| 情報・特殊機能 | `--color-info` | #2196f3 |

### 具体的な修正箇所
1. **AdminWindow.css**
   - 保存ボタン: `--color-success-light` → `--color-success`
   - リセットボタン: `--color-danger-light` → `--color-danger`

2. **Header.css**
   - ピンボタン(常に最上面): `--color-danger-light` → `--color-danger-alt`

3. **HotkeyInput.css**
   - ホットキー記録中の枠線: `--color-danger-light` → `--color-danger`
   - 記録中インジケーター背景: `--color-danger-light` → `--color-danger`

4. **EditMode.css**
   - グループ選択ボタンのスタイルを新規追加（青色）

5. **common.css**
   - `.btn-info` クラスを新規追加（特殊機能ボタン用）

## Test plan
- [x] ビルド確認 (npm run build) - 成功
- [x] 設定タブテスト (6/6 成功)
- [x] グループアイテム登録テスト (9/9 成功)
- [x] アイテム管理テスト (12/15 成功、3失敗は既存の問題)

## 影響範囲
- 管理画面の設定タブ: 保存・リセットボタンの色が若干変更
- ホットキー入力: 記録中の表示色が統一
- アイテム管理: グループ選択ボタンに色が適用される

## スクリーンショット
実機で確認してください：
- 設定タブの保存・リセットボタン
- アイテム管理のグループ選択ボタン

🤖 Generated with [Claude Code](https://claude.com/claude-code)