### PR TITLE
管理画面のフォントサイズをCSS変数に統一

### DIFF
--- a/src/renderer/styles/components/EditMode.css
+++ b/src/renderer/styles/components/EditMode.css
@@ -185,7 +185,7 @@
   background: transparent;
   border: none;
   border-radius: var(--border-radius-sm);
-  font-size: 20px;
+  font-size: var(--font-size-3xl);
   line-height: 1;
   color: var(--color-gray-600);
   cursor: pointer;
@@ -510,7 +510,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   padding: 0;
 }
 
@@ -647,7 +647,7 @@
 }
 
 .icon-column .folder-emoji {
-  font-size: 20px;
+  font-size: var(--font-size-3xl);
   line-height: 24px;
   display: inline-block;
   vertical-align: middle;
@@ -655,7 +655,7 @@
 
 .type-icon {
   margin-right: 4px;
-  font-size: 14px;
+  font-size: var(--font-size-base);
   display: inline-block;
   width: 16px;
   text-align: center;
@@ -679,20 +679,20 @@
 
 .content-column .editable-cell {
   font-family: monospace;
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   white-space: pre-wrap;
 }
 
 .content-column .edit-input {
   font-family: monospace;
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   white-space: pre;
   overflow-x: auto;
 }
 
 .raw-items-table .content-column .editable-cell {
   font-family: monospace;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   white-space: pre-wrap;
   min-height: 28px;
   line-height: 28px;
@@ -705,7 +705,7 @@
 
 .raw-items-table .content-column .edit-input {
   font-family: monospace;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   white-space: pre;
   overflow-x: auto;
   height: 28px;
@@ -744,6 +744,14 @@
   max-width: 300px;
   word-break: break-word;
   padding: 4px 8px !important;
+}
+
+.raw-items-table .name-column .editable-cell {
+  font-size: var(--font-size-sm);
+}
+
+.raw-items-table .name-column .edit-input {
+  font-size: var(--font-size-sm);
 }
 
 /* 可変幅の列 - パス列は残りの幅を使う */


### PR DESCRIPTION
## Summary

管理画面（EditMode）のフォントサイズをプロジェクトのCSSデザインシステムに準拠するよう、ハードコードされた値をCSS変数に置き換えました。これにより、名前列・コンテンツ列のフォントサイズが12pxに統一され、視覚的な一貫性が向上しました。

## 変更内容

### EditMode.cssのリファクタリング

以下10箇所のハードコードされたフォントサイズをCSS変数に置き換え：

1. **検索クリアボタン**: `20px` → `var(--font-size-3xl)`
2. **アクションボタン**: `12px` → `var(--font-size-sm)`
3. **フォルダ絵文字**: `20px` → `var(--font-size-3xl)`
4. **タイプアイコン**: `14px` → `var(--font-size-base)`
5. **コンテンツ列（編集可能）**: `13px` → `var(--font-size-sm)`
6. **コンテンツ列（入力）**: `13px` → `var(--font-size-sm)`
7. **生データテーブル（編集可能）**: `12px` → `var(--font-size-sm)`
8. **生データテーブル（入力）**: `12px` → `var(--font-size-sm)`
9. **名前列（編集可能）**: `var(--font-size-sm)` を新規追加
10. **名前列（入力）**: `var(--font-size-sm)` を新規追加

### 効果

- ✅ 名前列・コンテンツ列のフォントサイズが12pxに統一
- ✅ プロジェクトのCSSデザインシステムに完全準拠
- ✅ 将来のデザイン変更時のメンテナンス性が向上
- ✅ 視覚的な一貫性の改善

## Test plan

- [x] 開発モードで管理画面を開き、フォントサイズの統一を目視確認
- [x] TypeScript型チェック（エラー0件）
- [x] ESLintチェック（本番コードエラー0件）
- [ ] E2Eテスト（item-management）実行

## 関連Issue

このPRは以前のアイコン表示機能追加（#110）のフォローアップとして、管理画面の視覚的一貫性を改善するものです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)