### PR TITLE
fix(backup): 起動時バックアップとファイル削除時バックアップを改善

### DIFF
--- a/src/main/ipc/dataHandlers.ts
+++ b/src/main/ipc/dataHandlers.ts
@@ -1102,6 +1102,10 @@ export function setupDataHandlers(configFolder: string) {
     const filePath = path.join(configFolder, fileName);
 
     try {
+      // 削除前にバックアップを作成（設定に基づく）
+      const backupService = await BackupService.getInstance();
+      await backupService.createBackup(filePath);
+
       await fs.unlink(filePath);
       // notifyDataChanged(); // 設定の再読み込みを防ぐため削除
       return { success: true };

--- a/src/main/services/backupService.ts
+++ b/src/main/services/backupService.ts
@@ -206,7 +206,8 @@ export class BackupService {
       return;
     }
 
-    const files = ['data.txt', 'data2.txt'];
+    // 動的にdata*.txtファイルを取得
+    const files = PathManager.getDataFiles();
     const backupFolder = path.join(configFolder, 'backup');
 
     for (const file of files) {


### PR DESCRIPTION
## Summary
- 起動時バックアップを動的ファイル検出に変更
- ファイル削除時のバックアップ機能を追加

## 変更内容

### 起動時バックアップの改善
- **問題**: data.txt, data2.txtのみハードコード → data3.txt以降がバックアップされない
- **修正**: PathManager.getDataFiles()で動的にdata*.txtファイルを検出
- **効果**: タブ追加機能で作成されたすべてのデータファイルが自動的にバックアップ対象に

### ファイル削除時バックアップの追加
- **問題**: データファイル削除時にバックアップなし → 誤削除時に復元不可能
- **修正**: BackupService.createBackup()を削除前に呼び出し
- **効果**: 設定に基づいてバックアップを作成し、データ損失リスクを軽減

## 変更ファイル
- `src/main/services/backupService.ts` (1行)
- `src/main/ipc/dataHandlers.ts` (3行)

## 品質チェック結果
- TypeScript型チェック: ✅ 合格
- ESLintチェック: ✅ 合格（警告は既存の未使用変数のみ）
- コード品質: ✅ 良好（既存機能の再利用）

## テスト結果
- E2Eテスト: ✅ すべて合格（94件）
- 実行時間: 7分6秒
- バックアップ機能修正による既存機能への影響なし

## Test plan
- [x] TypeScript型チェック
- [x] ESLint
- [x] E2Eテスト実行（94件すべて合格）
- [x] 既存機能の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)