### PR TITLE
fix: Electron 39.2.6のnode-abi互換性問題を解決

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quick-dash-launcher",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quick-dash-launcher",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "os": [
         "win32"
@@ -38,7 +38,7 @@
         "@vitest/ui": "^3.2.4",
         "concurrently": "^9.2.1",
         "cross-env": "^10.1.0",
-        "electron": "^39.2.6",
+        "electron": "^37.7.3",
         "electron-builder": "^26.0.12",
         "eslint": "^9.39.1",
         "eslint-config-prettier": "^10.1.8",
@@ -5036,9 +5036,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "39.2.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-39.2.6.tgz",
-      "integrity": "sha512-dHBgTodWBZd+tL1Dt0PSh/CFLHeDkFCTKCTXu1dgPhlE9Z3k2zzlBQ9B2oW55CFsKanBDHiUomHJNw0XaSdQpA==",
+      "version": "37.10.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.10.3.tgz",
+      "integrity": "sha512-3IjCGSjQmH50IbW2PFveaTzK+KwcFX9PEhE7KXb9v5IT8cLAiryAN7qezm/XzODhDRlLu0xKG1j8xWBtZ/bx/g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@vitest/ui": "^3.2.4",
     "concurrently": "^9.2.1",
     "cross-env": "^10.1.0",
-    "electron": "^39.2.6",
+    "electron": "^37.7.3",
     "electron-builder": "^26.0.12",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
## 概要
GitHub Actionsでのビルドエラーを解決しました。

## 問題
Electron 39.2.6が新しすぎて、`@electron/rebuild`が使用する`node-abi`パッケージがこのバージョンのABIを認識できず、ネイティブモジュール`extract-file-icon`のリビルドに失敗していました。

```
⨯ Could not detect abi for version 39.2.6 and runtime electron.
```

## 解決策
Electronを**39.2.6 → 37.7.3**にダウングレードすることで、node-abiの互換性問題を解決しました。

## テスト結果
- ローカルでのビルドテストでは、ネイティブモジュールのリビルドが成功することを確認
- GitHub Actionsでの動作確認が必要

## 変更内容
- `package.json`: Electronバージョンを37.7.3に変更
- `package-lock.json`: 依存関係を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)