### PR TITLE
ワークスペースUIのレイアウト最適化

### DIFF
--- a/src/renderer/styles/components/WorkspaceWindow.css
+++ b/src/renderer/styles/components/WorkspaceWindow.css
@@ -87,7 +87,7 @@
   justify-content: space-between;
   border-radius: var(--border-radius);
   transition: var(--transition-fast);
-  margin-bottom: var(--spacing-xs);
+  margin-bottom: var(--spacing-xxs);
   background-color: var(--color-white);
   border: 1px solid var(--color-gray-400);
   box-shadow: var(--shadow-sm);
@@ -239,13 +239,13 @@
 
 /* グループコンテナ */
 .workspace-group {
-  margin-bottom: var(--spacing-md);
+  margin-bottom: var(--spacing-sm);
 }
 
 /* グループヘッダー */
 .workspace-group-header {
   position: relative;
-  padding: var(--spacing-sm) 60px var(--spacing-sm) var(--spacing-md);
+  padding: var(--spacing-xxs) 45px var(--spacing-xxs) var(--spacing-xs);
   background: linear-gradient(
     135deg,
     var(--group-color, var(--color-primary)),
@@ -254,7 +254,7 @@
   border-radius: var(--border-radius);
   display: flex;
   align-items: center;
-  gap: var(--spacing-sm);
+  gap: var(--spacing-xs);
   cursor: pointer;
   border-left: 4px solid var(--group-color, var(--color-primary));
   transition: var(--transition-fast);
@@ -267,7 +267,7 @@
 
 /* 折りたたみアイコン */
 .workspace-group-collapse-icon {
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
   transition: transform 0.2s ease;
   flex-shrink: 0;
 }
@@ -279,8 +279,8 @@
 /* グループ名 */
 .workspace-group-name {
   font-weight: 600;
-  color: var(--text-color);
-  font-size: 14px;
+  color: var(--color-white);
+  font-size: 12px;
   flex-shrink: 0;
   max-width: 150px;
   overflow: hidden;

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -74,6 +74,7 @@
   --border-radius-xl: 8px;
 
   /* スペーシング */
+  --spacing-xxs: 1px;
   --spacing-xs: 4px;
   --spacing-sm: 8px;
   --spacing-md: 12px;


### PR DESCRIPTION
## Summary

ワークスペースウィンドウのUIレイアウトを最適化し、よりコンパクトで視認性の高いデザインに改善しました。

### 変更内容

- **グループ・アイテム間隔の縮小**: グループ間を12px→8px、アイテム間を4px→1pxに変更
- **グループヘッダーのコンパクト化**: パディングとフォントサイズを削減し、省スペース化
- **グループ名の視認性向上**: 青背景に対して白色テキストを使用し、可読性を改善
- **新しいスペーシング変数**: `--spacing-xxs (1px)` を追加し、CSS変数体系を拡張

### 影響範囲

- `src/renderer/styles/variables.css`: 新しいスペーシング変数の追加
- `src/renderer/styles/components/WorkspaceWindow.css`: レイアウト調整

### Test plan

- [x] ワークスペースウィンドウの表示確認
- [x] グループの折りたたみ/展開動作確認
- [x] 視認性の改善確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)