### PR TITLE
feat: ワークスペースのUI改善（折りたたみ機能とアイコン化）

### DIFF
--- a/src/renderer/WorkspaceApp.tsx
+++ b/src/renderer/WorkspaceApp.tsx
@@ -10,6 +10,8 @@ const WorkspaceApp: React.FC = () => {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [isDraggingOver, setIsDraggingOver] = useState(false);
   const [isPinned, setIsPinned] = useState(false);
+  const [uncategorizedCollapsed, setUncategorizedCollapsed] = useState(false);
+  const [historyCollapsed, setHistoryCollapsed] = useState(false);
 
   useEffect(() => {
     loadItems();
@@ -297,17 +299,54 @@ const WorkspaceApp: React.FC = () => {
     setIsPinned(newState);
   };
 
+  const handleExpandAll = async () => {
+    // 全てのグループを展開
+    for (const group of groups) {
+      if (group.collapsed) {
+        await window.electronAPI.workspaceAPI.updateGroup(group.id, { collapsed: false });
+      }
+    }
+    await loadGroups();
+    // 未分類と実行履歴も展開
+    setUncategorizedCollapsed(false);
+    setHistoryCollapsed(false);
+  };
+
+  const handleCollapseAll = async () => {
+    // 全てのグループを閉じる
+    for (const group of groups) {
+      if (!group.collapsed) {
+        await window.electronAPI.workspaceAPI.updateGroup(group.id, { collapsed: true });
+      }
+    }
+    await loadGroups();
+    // 未分類と実行履歴も閉じる
+    setUncategorizedCollapsed(true);
+    setHistoryCollapsed(true);
+  };
+
   return (
     <div className={`workspace-window ${isDraggingOver ? 'dragging-over' : ''}`}>
       <div className="workspace-header">
         <h1>Workspace</h1>
-        <button
-          className={`workspace-pin-btn ${isPinned ? 'pinned' : ''}`}
-          onClick={handleTogglePin}
-          title={isPinned ? 'ピン留めを解除' : 'ピン留めして最前面に固定'}
-        >
-          📌
-        </button>
+        <div className="workspace-header-controls">
+          <button className="workspace-control-btn" onClick={handleExpandAll} title="全て展開">
+            🔽
+          </button>
+          <button className="workspace-control-btn" onClick={handleCollapseAll} title="全て閉じる">
+            🔼
+          </button>
+          <button className="workspace-control-btn" onClick={handleAddGroup} title="グループを追加">
+            ➕
+          </button>
+          <button
+            className={`workspace-pin-btn ${isPinned ? 'pinned' : ''}`}
+            onClick={handleTogglePin}
+            title={isPinned ? 'ピン留めを解除' : 'ピン留めして最前面に固定'}
+          >
+            📌
+          </button>
+        </div>
       </div>
       <WorkspaceGroupedList
         groups={groups}
@@ -320,11 +359,14 @@ const WorkspaceApp: React.FC = () => {
         onToggleGroup={handleToggleGroup}
         onUpdateGroup={handleUpdateGroup}
         onDeleteGroup={handleDeleteGroup}
-        onAddGroup={handleAddGroup}
         onMoveItemToGroup={handleMoveItemToGroup}
         onReorderGroups={handleReorderGroups}
         editingItemId={editingId}
         setEditingItemId={setEditingId}
+        uncategorizedCollapsed={uncategorizedCollapsed}
+        onToggleUncategorized={() => setUncategorizedCollapsed(!uncategorizedCollapsed)}
+        historyCollapsed={historyCollapsed}
+        onToggleHistory={() => setHistoryCollapsed(!historyCollapsed)}
       />
     </div>
   );

--- a/src/renderer/styles/components/WorkspaceWindow.css
+++ b/src/renderer/styles/components/WorkspaceWindow.css
@@ -28,6 +28,40 @@
   color: var(--text-color);
 }
 
+/* ヘッダーコントロール */
+.workspace-header-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+/* コントロールボタン（全て展開・全て閉じる） */
+.workspace-control-btn {
+  width: 32px;
+  height: 32px;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--color-gray-400);
+  background-color: var(--color-white);
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--transition-normal);
+  flex-shrink: 0;
+}
+
+.workspace-control-btn:hover {
+  background-color: var(--bg-hover);
+  border-color: var(--color-gray-600);
+}
+
+.workspace-control-btn:active {
+  transform: scale(0.95);
+}
+
 /* ピンボタン */
 .workspace-pin-btn {
   width: 32px;
@@ -373,6 +407,18 @@
   font-weight: 600;
   padding: var(--spacing-xs) var(--spacing-md);
   margin-bottom: var(--spacing-xs);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  user-select: none;
+}
+
+/* 折りたたみアイコン（未分類・実行履歴用） */
+.workspace-collapse-icon {
+  font-size: 10px;
+  transition: transform 0.2s ease;
+  display: inline-block;
+  width: 12px;
 }
 
 /* 実行履歴セクション */


### PR DESCRIPTION
## Summary

ワークスペースウィンドウのUIを改善し、より直感的でコンパクトなデザインに変更しました。

### 主な変更内容

#### 1. 折りたたみ機能の拡張
- **未分類セクション**と**実行履歴セクション**に折りたたみ機能を追加
- ヘッダークリックで展開/折りたたみが可能
- 各セクションにアイテム数を表示（例: 未分類 (5)）

#### 2. ヘッダーコントロールのアイコン化
- 「全て展開」ボタン → 🔽 アイコン
- 「全て閉じる」ボタン → 🔼 アイコン
- グループ追加ボタンをヘッダーに移動 → ➕ アイコン
- すべてのボタンを32x32pxの統一デザインに変更

#### 3. UIのコンパクト化
- リスト上部の「+ グループを追加」ボタンを削除
- すべてのコントロールをヘッダーに集約
- ピンボタンと統一感のあるデザイン

### 最終的なヘッダーレイアウト
```
Workspace  [🔽][🔼][➕][📌]
           展開 閉じる 追加 ピン
```

### 変更ファイル
- `src/renderer/WorkspaceApp.tsx` - 状態管理と展開/閉じる機能の実装
- `src/renderer/components/WorkspaceGroupedList.tsx` - 未分類・実行履歴の折りたたみUI
- `src/renderer/styles/components/WorkspaceWindow.css` - スタイル追加

## Test plan

- [ ] ワークスペースウィンドウを開く
- [ ] 未分類セクションのヘッダーをクリックして折りたたみ/展開を確認
- [ ] 実行履歴セクションのヘッダーをクリックして折りたたみ/展開を確認
- [ ] 🔽ボタンをクリックして全セクション（グループ+未分類+実行履歴）が展開されることを確認
- [ ] 🔼ボタンをクリックして全セクション（グループ+未分類+実行履歴）が閉じることを確認
- [ ] ➕ボタンをクリックして新しいグループが作成されることを確認
- [ ] 各ボタンのツールチップ（title属性）が表示されることを確認
- [ ] ヘッダーのボタンが統一的なデザインで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)