### PR TITLE
feat: ワークスペースのレイアウト調整（スペース縮小）

### DIFF
--- a/src/renderer/styles/components/WorkspaceWindow.css
+++ b/src/renderer/styles/components/WorkspaceWindow.css
@@ -273,7 +273,7 @@
 
 /* グループコンテナ */
 .workspace-group {
-  margin-bottom: var(--spacing-sm);
+  margin-bottom: var(--spacing-xs);
 }
 
 /* グループヘッダー */
@@ -396,8 +396,8 @@
 
 /* 未分類セクション */
 .workspace-uncategorized-section {
-  margin-top: var(--spacing-lg);
-  padding-top: var(--spacing-lg);
+  margin-top: var(--spacing-xs);
+  padding-top: var(--spacing-xs);
   border-top: 1px solid var(--border-color);
 }
 
@@ -423,8 +423,8 @@
 
 /* 実行履歴セクション */
 .workspace-execution-history-section {
-  margin-top: var(--spacing-lg);
-  padding-top: var(--spacing-lg);
+  margin-top: var(--spacing-xs);
+  padding-top: var(--spacing-xs);
   border-top: 1px solid var(--border-color);
 }
 


### PR DESCRIPTION
## Summary
- グループ間のスペースを縮小（8px → 4px）
- 未分類セクションの上部スペースを縮小（32px → 8px）
- 実行履歴セクションの上部スペースを縮小（32px → 8px）

ワークスペースのレイアウトをより密にして、スクロール量を削減し、一度に表示できる情報量を増やしました。

## 変更内容
`WorkspaceWindow.css`のスペーシング値を変更：
- `.workspace-group`の`margin-bottom`: `var(--spacing-sm)` → `var(--spacing-xs)`
- `.workspace-uncategorized-section`の`margin-top`と`padding-top`: `var(--spacing-lg)` → `var(--spacing-xs)`
- `.workspace-execution-history-section`の`margin-top`と`padding-top`: `var(--spacing-lg)` → `var(--spacing-xs)`

## Test plan
- [ ] ワークスペース画面を開き、グループ、未分類、実行履歴セクションのスペースが適切に縮小されていることを確認
- [ ] 複数のグループがある場合、グループ間のスペースが狭くなっていることを確認
- [ ] レイアウトが崩れていないことを確認
- [ ] スクロール時の動作に問題がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)