### PR TITLE
ワークスペースのグループ削除UIを改善

### DIFF
--- a/src/main/ipc/windowHandlers.ts
+++ b/src/main/ipc/windowHandlers.ts
@@ -16,6 +16,7 @@ import {
   hideWorkspaceWindow,
   getWorkspaceAlwaysOnTop,
   toggleWorkspaceAlwaysOnTop,
+  setWorkspaceModalMode,
 } from '../workspaceWindowManager.js';
 import { getTray } from '../windowManager.js';
 
@@ -124,4 +125,12 @@ export function setupWindowHandlers(
   ipcMain.handle('workspace:toggle-always-on-top', () => {
     return toggleWorkspaceAlwaysOnTop();
   });
+
+  // ワークスペースウィンドウのモーダルモード関連ハンドラー
+  ipcMain.handle(
+    'workspace:set-modal-mode',
+    (_event, isModal: boolean, requiredSize?: { width: number; height: number }) => {
+      setWorkspaceModalMode(isModal, requiredSize);
+    }
+  );
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -208,5 +208,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // ピン留め関連
     getAlwaysOnTop: (): Promise<boolean> => ipcRenderer.invoke('workspace:get-always-on-top'),
     toggleAlwaysOnTop: (): Promise<boolean> => ipcRenderer.invoke('workspace:toggle-always-on-top'),
+    // モーダルモード関連
+    setModalMode: (isModal: boolean, requiredSize?: { width: number; height: number }) =>
+      ipcRenderer.invoke('workspace:set-modal-mode', isModal, requiredSize),
   },
 });

--- a/src/main/workspaceWindowManager.ts
+++ b/src/main/workspaceWindowManager.ts
@@ -7,6 +7,7 @@ let workspaceWindow: BrowserWindow | null = null;
 let isWorkspaceWindowVisible: boolean = false;
 let isAppQuitting: boolean = false;
 let isWorkspacePinned: boolean = false;
+let normalWorkspaceWindowBounds: { width: number; height: number } | null = null;
 
 /**
  * ワークスペースウィンドウを作成し、初期設定を行う
@@ -207,4 +208,40 @@ export function toggleWorkspaceAlwaysOnTop(): boolean {
  */
 export function getWorkspaceAlwaysOnTop(): boolean {
   return isWorkspacePinned;
+}
+
+/**
+ * ワークスペースウィンドウのモーダルモードの切り替え
+ * モーダル表示時は必要に応じてウィンドウサイズを拡大し、閉じる時は元のサイズに戻す
+ */
+export function setWorkspaceModalMode(
+  isModal: boolean,
+  requiredSize?: { width: number; height: number }
+): void {
+  if (workspaceWindow && !workspaceWindow.isDestroyed()) {
+    if (isModal && requiredSize) {
+      // モーダル表示時：現在のサイズを保存し、必要な場合のみ拡大
+      const currentBounds = workspaceWindow.getBounds();
+      normalWorkspaceWindowBounds = { width: currentBounds.width, height: currentBounds.height };
+
+      // 必要サイズと現在サイズを比較し、必要な場合のみ拡大
+      if (currentBounds.width < requiredSize.width || currentBounds.height < requiredSize.height) {
+        workspaceWindow.setSize(
+          Math.max(currentBounds.width, requiredSize.width),
+          Math.max(currentBounds.height, requiredSize.height)
+        );
+        // ワークスペースウィンドウは画面右端に固定されるため、center()は呼ばない
+      }
+    } else {
+      // モーダルを閉じる時：元のサイズに復元
+      if (normalWorkspaceWindowBounds) {
+        workspaceWindow.setSize(
+          normalWorkspaceWindowBounds.width,
+          normalWorkspaceWindowBounds.height
+        );
+        // ワークスペースウィンドウは画面右端に固定されるため、center()は呼ばない
+        normalWorkspaceWindowBounds = null;
+      }
+    }
+  }
 }

--- a/src/renderer/components/ConfirmDialog.tsx
+++ b/src/renderer/components/ConfirmDialog.tsx
@@ -12,6 +12,10 @@ interface ConfirmDialogProps {
   confirmText?: string;
   cancelText?: string;
   danger?: boolean;
+  showCheckbox?: boolean;
+  checkboxLabel?: string;
+  checkboxChecked?: boolean;
+  onCheckboxChange?: (checked: boolean) => void;
 }
 
 const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
@@ -23,6 +27,10 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   confirmText = 'OK',
   cancelText = 'キャンセル',
   danger = false,
+  showCheckbox = false,
+  checkboxLabel = '',
+  checkboxChecked = false,
+  onCheckboxChange,
 }) => {
   useEffect(() => {
     if (!isOpen) return;
@@ -63,6 +71,19 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
 
         <div className="confirm-body">
           <p>{message}</p>
+          {showCheckbox && (
+            <div className="confirm-checkbox-container">
+              <label className="confirm-checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={checkboxChecked}
+                  onChange={(e) => onCheckboxChange?.(e.target.checked)}
+                  data-testid="confirm-dialog-checkbox"
+                />
+                <span>{checkboxLabel}</span>
+              </label>
+            </div>
+          )}
         </div>
 
         <div className="modal-actions">

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -144,6 +144,8 @@ export interface ElectronAPI {
     // ピン留め関連
     getAlwaysOnTop: () => Promise<boolean>;
     toggleAlwaysOnTop: () => Promise<boolean>;
+    // モーダルモード関連
+    setModalMode: (isModal: boolean, requiredSize?: { width: number; height: number }) => void;
   };
   // ワークスペースウィンドウ制御API
   toggleWorkspaceWindow: () => Promise<void>;

--- a/src/renderer/styles/components/ConfirmDialog.css
+++ b/src/renderer/styles/components/ConfirmDialog.css
@@ -1,7 +1,7 @@
 /* ConfirmDialog スタイル */
 
 .confirm-dialog {
-  max-width: 450px;
+  max-width: 550px;
   width: 90%;
   padding: var(--spacing-xl);
 }
@@ -81,4 +81,43 @@
 
 .confirm-dialog .danger-button:hover {
   background-color: var(--color-danger-hover);
+}
+
+/* チェックボックスコンテナ */
+.confirm-checkbox-container {
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm);
+  background-color: var(--color-gray-100);
+  border-radius: var(--border-radius);
+  border-left: 3px solid var(--color-primary);
+}
+
+/* チェックボックスラベル */
+.confirm-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  cursor: pointer;
+  user-select: none;
+  font-size: var(--font-size-base);
+  color: var(--text-color);
+}
+
+/* チェックボックス入力 */
+.confirm-checkbox-label input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: var(--color-primary);
+}
+
+/* dangerモード時のチェックボックスコンテナ */
+.confirm-dialog.confirm-danger .confirm-checkbox-container {
+  border-left-color: var(--color-danger);
+  background-color: color-mix(in srgb, var(--color-danger) 5%, var(--color-gray-100));
+}
+
+/* dangerモード時のチェックボックス */
+.confirm-dialog.confirm-danger .confirm-checkbox-label input[type='checkbox'] {
+  accent-color: var(--color-danger);
 }


### PR DESCRIPTION
## Summary

- window.confirm()からカスタムConfirmDialogに変更してUIの統一感を向上
- チェックボックスでグループ内のアイテムの削除を選択可能に
  - デフォルトはOFF（アイテムを未分類に移動）
  - チェックONでグループとアイテムの両方を削除
- ダイアログ表示時にワークスペースウィンドウを自動拡大する機能を追加
- ConfirmDialogにチェックボックス機能を追加（汎用的なオプション機能）

## 変更内容の詳細

### 1. ConfirmDialogコンポーネントの拡張
- チェックボックス機能を追加（`showCheckbox`, `checkboxLabel`, `checkboxChecked`, `onCheckboxChange`）
- dangerモード時の赤系スタイルに対応
- ダイアログの最大幅を450pxから550pxに拡大

### 2. ワークスペースウィンドウのモーダルモード機能
- `setWorkspaceModalMode`関数を実装（workspaceWindowManager.ts）
- ダイアログ表示時にウィンドウを自動拡大（600x400px）
- ダイアログを閉じる時に元のサイズに復元
- 画面右端の位置を維持（center()は呼ばない）

### 3. グループ削除処理の改善
- window.confirm()をConfirmDialogに置き換え
- 状態管理とuseEffectでモーダルモードを制御
- OKとキャンセルの動作を直感的に変更

## Test plan

- [ ] ワークスペースウィンドウでグループを作成
- [ ] グループにアイテムを追加
- [ ] グループ削除ボタン（🗑️）をクリック
- [ ] カスタムConfirmDialogが表示されることを確認
- [ ] ワークスペースウィンドウが自動的に広がることを確認
- [ ] チェックボックスがデフォルトでOFFになっていることを確認
- [ ] チェックボックスOFFで削除を実行し、アイテムが未分類に移動することを確認
- [ ] チェックボックスONで削除を実行し、グループとアイテムの両方が削除されることを確認
- [ ] キャンセルボタンで削除がキャンセルされることを確認
- [ ] ダイアログを閉じた時にウィンドウが元のサイズに戻ることを確認
- [ ] ウィンドウの位置が画面右端を維持していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)