### PR TITLE
feat: ワークスペースのグループ色選択機能を追加

### DIFF
--- a/src/renderer/components/ColorPicker.tsx
+++ b/src/renderer/components/ColorPicker.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useRef } from 'react';
+
+import { GROUP_COLOR_PALETTE } from '../constants/colorPalette';
+
+interface ColorPickerProps {
+  /** 色選択時のコールバック */
+  onSelectColor: (colorValue: string) => void;
+  /** 閉じる際のコールバック */
+  onClose: () => void;
+  /** 現在選択されている色 */
+  currentColor?: string;
+}
+
+/**
+ * グループ色選択用のカラーピッカーコンポーネント
+ * プリセット色をグリッド表示し、クリック時に色を選択
+ */
+const ColorPicker: React.FC<ColorPickerProps> = ({ onSelectColor, onClose, currentColor }) => {
+  const pickerRef = useRef<HTMLDivElement>(null);
+
+  // ESCキーで閉じる
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onClose]);
+
+  // 外側クリックで閉じる
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+
+    // 少し遅延させてから外側クリック検出を有効にする
+    // （ボタンクリックで開いた直後に閉じるのを防ぐ）
+    const timer = setTimeout(() => {
+      document.addEventListener('mousedown', handleClickOutside);
+    }, 100);
+
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [onClose]);
+
+  const handleColorClick = (colorValue: string) => {
+    onSelectColor(colorValue);
+  };
+
+  return (
+    <div className="color-picker-dropdown" ref={pickerRef}>
+      <div className="color-picker-grid">
+        {GROUP_COLOR_PALETTE.map((color) => (
+          <button
+            key={color.value}
+            className={`color-picker-option ${currentColor === color.value ? 'selected' : ''}`}
+            style={{ backgroundColor: color.value }}
+            onClick={() => handleColorClick(color.value)}
+            title={color.name}
+            type="button"
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ColorPicker;

--- a/src/renderer/components/WorkspaceGroupHeader.tsx
+++ b/src/renderer/components/WorkspaceGroupHeader.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useRef, useEffect } from 'react';
 import type { WorkspaceGroup } from '@common/types';
 
+import ColorPicker from './ColorPicker';
+
 interface WorkspaceGroupHeaderProps {
   group: WorkspaceGroup;
   itemCount: number;
@@ -30,6 +32,7 @@ const WorkspaceGroupHeader: React.FC<WorkspaceGroupHeaderProps> = ({
 }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState(group.name);
+  const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   // 編集モードに入ったときにフォーカス
@@ -74,6 +77,16 @@ const WorkspaceGroupHeader: React.FC<WorkspaceGroupHeaderProps> = ({
     onDelete(group.id);
   };
 
+  const handleColorButtonClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsColorPickerOpen(!isColorPickerOpen);
+  };
+
+  const handleColorSelect = (color: string) => {
+    onUpdate(group.id, { color });
+    setIsColorPickerOpen(false);
+  };
+
   const handleDragStart = (e: React.DragEvent) => {
     // 編集モード中はドラッグを無効化
     if (isEditing) {
@@ -106,7 +119,7 @@ const WorkspaceGroupHeader: React.FC<WorkspaceGroupHeaderProps> = ({
 
   return (
     <div
-      className="workspace-group-header"
+      className={`workspace-group-header ${isColorPickerOpen ? 'color-picker-open' : ''}`}
       onClick={handleToggle}
       onDragOver={handleDragOver}
       onDrop={handleDrop}
@@ -151,6 +164,13 @@ const WorkspaceGroupHeader: React.FC<WorkspaceGroupHeaderProps> = ({
       {/* 編集・削除ボタン */}
       <div className="workspace-group-actions">
         <button
+          className="workspace-group-color-btn"
+          onClick={handleColorButtonClick}
+          title="グループの色を変更"
+        >
+          🎨
+        </button>
+        <button
           className="workspace-group-edit-btn"
           onClick={handleStartEdit}
           title="グループ名を編集"
@@ -165,6 +185,15 @@ const WorkspaceGroupHeader: React.FC<WorkspaceGroupHeaderProps> = ({
           🗑️
         </button>
       </div>
+
+      {/* カラーピッカー（actionsの外に配置） */}
+      {isColorPickerOpen && (
+        <ColorPicker
+          onSelectColor={handleColorSelect}
+          onClose={() => setIsColorPickerOpen(false)}
+          currentColor={group.color}
+        />
+      )}
     </div>
   );
 };

--- a/src/renderer/constants/colorPalette.ts
+++ b/src/renderer/constants/colorPalette.ts
@@ -1,0 +1,48 @@
+/**
+ * ワークスペースグループのプリセット色パレット
+ */
+
+export interface ColorPaletteItem {
+  /** 色の名前 */
+  name: string;
+  /** CSS変数名またはカラーコード */
+  value: string;
+}
+
+/**
+ * グループ色選択用のプリセット色パレット（8色）
+ */
+export const GROUP_COLOR_PALETTE: ColorPaletteItem[] = [
+  {
+    name: 'プライマリ',
+    value: 'var(--color-primary)',
+  },
+  {
+    name: 'サクセス',
+    value: 'var(--color-success)',
+  },
+  {
+    name: 'ダンジャー',
+    value: 'var(--color-danger)',
+  },
+  {
+    name: 'ワーニング',
+    value: 'var(--color-warning)',
+  },
+  {
+    name: 'インフォ',
+    value: 'var(--color-info)',
+  },
+  {
+    name: 'セカンダリ',
+    value: 'var(--color-secondary)',
+  },
+  {
+    name: 'パープル',
+    value: '#9c27b0',
+  },
+  {
+    name: 'ティール',
+    value: '#00897b',
+  },
+];

--- a/src/renderer/styles/components/ColorPicker.css
+++ b/src/renderer/styles/components/ColorPicker.css
@@ -1,0 +1,52 @@
+/* カラーピッカードロップダウン */
+.color-picker-dropdown {
+  position: absolute;
+  top: calc(100% + var(--spacing-xxs));
+  right: var(--spacing-xs);
+  background-color: var(--color-white);
+  border: 1px solid var(--color-gray-400);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-lg);
+  padding: var(--spacing-md);
+  z-index: 9999;
+  min-width: 200px;
+}
+
+/* 色グリッドレイアウト（2行×4列） */
+.color-picker-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--spacing-sm);
+}
+
+/* 色オプションボタン */
+.color-picker-option {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: var(--transition-normal);
+  background-color: currentColor;
+  padding: 0;
+}
+
+.color-picker-option:hover {
+  border-color: var(--color-gray-600);
+  transform: scale(1.1);
+  box-shadow: var(--shadow);
+}
+
+.color-picker-option:active {
+  transform: scale(0.95);
+}
+
+/* 選択中の色 */
+.color-picker-option.selected {
+  border-color: var(--color-primary);
+  border-width: 3px;
+}
+
+.color-picker-option.selected:hover {
+  border-color: var(--color-primary-hover);
+}

--- a/src/renderer/styles/components/WorkspaceWindow.css
+++ b/src/renderer/styles/components/WorkspaceWindow.css
@@ -293,10 +293,16 @@
   border-left: 4px solid var(--group-color, var(--color-primary));
   transition: var(--transition-fast);
   user-select: none;
+  z-index: 10;
 }
 
 .workspace-group-header:hover {
   filter: brightness(1.05);
+}
+
+/* カラーピッカーが開いている時は最前面に */
+.workspace-group-header.color-picker-open {
+  z-index: 9998;
 }
 
 /* 折りたたみアイコン */
@@ -355,6 +361,7 @@
 
 /* グループアクション（編集・削除ボタン） */
 .workspace-group-actions {
+  position: relative;
   display: flex;
   gap: var(--spacing-xs);
   opacity: 0;
@@ -365,6 +372,7 @@
   opacity: 1;
 }
 
+.workspace-group-color-btn,
 .workspace-group-edit-btn,
 .workspace-group-delete-btn {
   background: none;
@@ -374,6 +382,10 @@
   padding: 4px;
   border-radius: var(--border-radius);
   transition: background-color 0.2s ease;
+}
+
+.workspace-group-color-btn:hover {
+  background-color: rgba(255, 255, 255, 0.2);
 }
 
 .workspace-group-edit-btn:hover {

--- a/src/renderer/workspace/index.tsx
+++ b/src/renderer/workspace/index.tsx
@@ -5,6 +5,7 @@ import WorkspaceApp from '../WorkspaceApp';
 import '../styles/index.css';
 import '../styles/components/WorkspaceWindow.css';
 import '../styles/components/ContextMenu.css';
+import '../styles/components/ColorPicker.css';
 
 const rootElement = document.getElementById('workspace-root');
 if (!rootElement) {


### PR DESCRIPTION
## Summary
グループヘッダーに色変更ボタン（🎨）を追加し、8色のプリセット色からグループの背景色を変更できる機能を実装しました。

## 実装内容
- ✅ プリセット色パレット（8色）の定義
- ✅ カラーピッカーコンポーネントの作成
- ✅ グループヘッダーへの色変更ボタン追加
- ✅ ESCキーと外側クリックでカラーピッカーを閉じる
- ✅ z-index調整により未分類セクションの上に正しく表示

## 変更ファイル
- 新規作成: `src/renderer/constants/colorPalette.ts`
- 新規作成: `src/renderer/components/ColorPicker.tsx`
- 新規作成: `src/renderer/styles/components/ColorPicker.css`
- 修正: `src/renderer/components/WorkspaceGroupHeader.tsx`
- 修正: `src/renderer/styles/components/WorkspaceWindow.css`
- 修正: `src/renderer/workspace/index.tsx`

## 使い方
1. ワークスペースウィンドウを開く
2. グループヘッダーにマウスを乗せると🎨アイコンが表示
3. クリックで8色のプリセット色パレットを表示
4. 色を選択すると即座にグループの背景色が変更
5. ESCキーまたは外側クリックでカラーピッカーを閉じる

## 品質チェック
- ✅ TypeScript型チェック合格
- ✅ ESLint合格
- ✅ コード品質チェック合格

## Test plan
- [x] 開発モードで動作確認済み
- [x] カラーピッカーが正しく表示される
- [x] 色選択が正常に動作する
- [x] ESCキーで閉じる
- [x] 外側クリックで閉じる
- [x] z-indexが正しく設定され、未分類セクションの上に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)